### PR TITLE
Add meta info to vcf header

### DIFF
--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -4,6 +4,8 @@ import argparse
 import ast
 import math
 import re
+import sys
+
 import yaml
 
 from itertools import chain
@@ -184,7 +186,19 @@ def main():
             fmt = "b"
         elif args.output_fmt == "uncompressed-bcf":
             fmt = "u"
-        with VariantFile(args.output, "w" + fmt, header=vcf.header,) as out:
+
+        header: VariantHeader = vcf.header
+        header.add_meta("vembraneVersion", __version__)
+        header.add_meta(
+            "vembraneCmd",
+            "vembrane "
+            + " ".join(
+                "'" + arg.replace("'", '"') + '"' if " " in arg else arg
+                for arg in sys.argv[1:]
+            ),
+        )
+
+        with VariantFile(args.output, "w" + fmt, header=header,) as out:
             records = filter_vcf(
                 vcf,
                 args.expression,


### PR DESCRIPTION
This PR adds vembraneVersion and vembraneCmd to the vcf's header.
I wonder if there's a canonical way to get the unmodified commandline (which is also testable, sys.argv isn't readily 'available' in test environments).