### PR TITLE
Added flag for correct parsing of VEP annotations keys

### DIFF
--- a/tests/test_vembrane.py
+++ b/tests/test_vembrane.py
@@ -40,6 +40,7 @@ def test_filter(testcase):
                     config.get("filter_expression"),
                     config.get("ann_key", "ANN"),
                     config.get("keep_unmatched", False),
+                    config.get("vep", False),
                 )
             )
     else:
@@ -50,6 +51,7 @@ def test_filter(testcase):
                 config.get("filter_expression"),
                 config.get("ann_key", "ANN"),
                 config.get("keep_unmatched", False),
+                config.get("vep", False)
             )
         )
         assert result == expected

--- a/tests/test_vembrane.py
+++ b/tests/test_vembrane.py
@@ -51,7 +51,7 @@ def test_filter(testcase):
                 config.get("filter_expression"),
                 config.get("ann_key", "ANN"),
                 config.get("keep_unmatched", False),
-                config.get("vep", False)
+                config.get("vep", False),
             )
         )
         assert result == expected

--- a/tests/test_vembrane.py
+++ b/tests/test_vembrane.py
@@ -40,7 +40,6 @@ def test_filter(testcase):
                     config.get("filter_expression"),
                     config.get("ann_key", "ANN"),
                     config.get("keep_unmatched", False),
-                    config.get("vep", False),
                 )
             )
     else:
@@ -51,7 +50,6 @@ def test_filter(testcase):
                 config.get("filter_expression"),
                 config.get("ann_key", "ANN"),
                 config.get("keep_unmatched", False),
-                config.get("vep", False),
             )
         )
         assert result == expected

--- a/tests/testcases/test09/config.yaml
+++ b/tests/testcases/test09/config.yaml
@@ -1,2 +1,1 @@
 filter_expression: 'ANN["IMPACT"] == "MODERATE"'
-vep: True

--- a/tests/testcases/test09/config.yaml
+++ b/tests/testcases/test09/config.yaml
@@ -1,0 +1,2 @@
+filter_expression: 'ANN["IMPACT"] == "MODERATE"'
+vep: True

--- a/tests/testcases/test09/expected.vcf
+++ b/tests/testcases/test09/expected.vcf
@@ -1,0 +1,245 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##contig=<ID=1,length=248956422>
+##contig=<ID=10,length=133797422>
+##contig=<ID=11,length=135086622>
+##contig=<ID=12,length=133275309>
+##contig=<ID=13,length=114364328>
+##contig=<ID=14,length=107043718>
+##contig=<ID=15,length=101991189>
+##contig=<ID=16,length=90338345>
+##contig=<ID=17,length=83257441>
+##contig=<ID=18,length=80373285>
+##contig=<ID=19,length=58617616>
+##contig=<ID=2,length=242193529>
+##contig=<ID=20,length=64444167>
+##contig=<ID=21,length=46709983>
+##contig=<ID=22,length=50818468>
+##contig=<ID=3,length=198295559>
+##contig=<ID=4,length=190214555>
+##contig=<ID=5,length=181538259>
+##contig=<ID=6,length=170805979>
+##contig=<ID=7,length=159345973>
+##contig=<ID=8,length=145138636>
+##contig=<ID=9,length=138394717>
+##contig=<ID=MT,length=16569>
+##contig=<ID=X,length=156040895>
+##contig=<ID=Y,length=57227415>
+##contig=<ID=KI270728.1,length=1872759>
+##contig=<ID=KI270727.1,length=448248>
+##contig=<ID=KI270442.1,length=392061>
+##contig=<ID=KI270729.1,length=280839>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=KI270743.1,length=210658>
+##contig=<ID=GL000008.2,length=209709>
+##contig=<ID=GL000009.2,length=201709>
+##contig=<ID=KI270747.1,length=198735>
+##contig=<ID=KI270722.1,length=194050>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=KI270742.1,length=186739>
+##contig=<ID=GL000205.2,length=185591>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=KI270736.1,length=181920>
+##contig=<ID=KI270733.1,length=179772>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=KI270719.1,length=176845>
+##contig=<ID=GL000216.2,length=176608>
+##contig=<ID=KI270712.1,length=176043>
+##contig=<ID=KI270706.1,length=175055>
+##contig=<ID=KI270725.1,length=172810>
+##contig=<ID=KI270744.1,length=168472>
+##contig=<ID=KI270734.1,length=165050>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=KI270715.1,length=161471>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=KI270749.1,length=158759>
+##contig=<ID=KI270741.1,length=157432>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=KI270716.1,length=153799>
+##contig=<ID=KI270731.1,length=150754>
+##contig=<ID=KI270751.1,length=150742>
+##contig=<ID=KI270750.1,length=148850>
+##contig=<ID=KI270519.1,length=138126>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=KI270708.1,length=127682>
+##contig=<ID=KI270730.1,length=112551>
+##contig=<ID=KI270438.1,length=112505>
+##contig=<ID=KI270737.1,length=103838>
+##contig=<ID=KI270721.1,length=100316>
+##contig=<ID=KI270738.1,length=99375>
+##contig=<ID=KI270748.1,length=93321>
+##contig=<ID=KI270435.1,length=92983>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=KI270538.1,length=91309>
+##contig=<ID=KI270756.1,length=79590>
+##contig=<ID=KI270739.1,length=73985>
+##contig=<ID=KI270757.1,length=71251>
+##contig=<ID=KI270709.1,length=66860>
+##contig=<ID=KI270746.1,length=66486>
+##contig=<ID=KI270753.1,length=62944>
+##contig=<ID=KI270589.1,length=44474>
+##contig=<ID=KI270726.1,length=43739>
+##contig=<ID=KI270735.1,length=42811>
+##contig=<ID=KI270711.1,length=42210>
+##contig=<ID=KI270745.1,length=41891>
+##contig=<ID=KI270714.1,length=41717>
+##contig=<ID=KI270732.1,length=41543>
+##contig=<ID=KI270713.1,length=40745>
+##contig=<ID=KI270754.1,length=40191>
+##contig=<ID=KI270710.1,length=40176>
+##contig=<ID=KI270717.1,length=40062>
+##contig=<ID=KI270724.1,length=39555>
+##contig=<ID=KI270720.1,length=39050>
+##contig=<ID=KI270723.1,length=38115>
+##contig=<ID=KI270718.1,length=38054>
+##contig=<ID=KI270317.1,length=37690>
+##contig=<ID=KI270740.1,length=37240>
+##contig=<ID=KI270755.1,length=36723>
+##contig=<ID=KI270707.1,length=32032>
+##contig=<ID=KI270579.1,length=31033>
+##contig=<ID=KI270752.1,length=27745>
+##contig=<ID=KI270512.1,length=22689>
+##contig=<ID=KI270322.1,length=21476>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=KI270311.1,length=12399>
+##contig=<ID=KI270366.1,length=8320>
+##contig=<ID=KI270511.1,length=8127>
+##contig=<ID=KI270448.1,length=7992>
+##contig=<ID=KI270521.1,length=7642>
+##contig=<ID=KI270581.1,length=7046>
+##contig=<ID=KI270582.1,length=6504>
+##contig=<ID=KI270515.1,length=6361>
+##contig=<ID=KI270588.1,length=6158>
+##contig=<ID=KI270591.1,length=5796>
+##contig=<ID=KI270522.1,length=5674>
+##contig=<ID=KI270507.1,length=5353>
+##contig=<ID=KI270590.1,length=4685>
+##contig=<ID=KI270584.1,length=4513>
+##contig=<ID=KI270320.1,length=4416>
+##contig=<ID=KI270382.1,length=4215>
+##contig=<ID=KI270468.1,length=4055>
+##contig=<ID=KI270467.1,length=3920>
+##contig=<ID=KI270362.1,length=3530>
+##contig=<ID=KI270517.1,length=3253>
+##contig=<ID=KI270593.1,length=3041>
+##contig=<ID=KI270528.1,length=2983>
+##contig=<ID=KI270587.1,length=2969>
+##contig=<ID=KI270364.1,length=2855>
+##contig=<ID=KI270371.1,length=2805>
+##contig=<ID=KI270333.1,length=2699>
+##contig=<ID=KI270374.1,length=2656>
+##contig=<ID=KI270411.1,length=2646>
+##contig=<ID=KI270414.1,length=2489>
+##contig=<ID=KI270510.1,length=2415>
+##contig=<ID=KI270390.1,length=2387>
+##contig=<ID=KI270375.1,length=2378>
+##contig=<ID=KI270420.1,length=2321>
+##contig=<ID=KI270509.1,length=2318>
+##contig=<ID=KI270315.1,length=2276>
+##contig=<ID=KI270302.1,length=2274>
+##contig=<ID=KI270518.1,length=2186>
+##contig=<ID=KI270530.1,length=2168>
+##contig=<ID=KI270304.1,length=2165>
+##contig=<ID=KI270418.1,length=2145>
+##contig=<ID=KI270424.1,length=2140>
+##contig=<ID=KI270417.1,length=2043>
+##contig=<ID=KI270508.1,length=1951>
+##contig=<ID=KI270303.1,length=1942>
+##contig=<ID=KI270381.1,length=1930>
+##contig=<ID=KI270529.1,length=1899>
+##contig=<ID=KI270425.1,length=1884>
+##contig=<ID=KI270396.1,length=1880>
+##contig=<ID=KI270363.1,length=1803>
+##contig=<ID=KI270386.1,length=1788>
+##contig=<ID=KI270465.1,length=1774>
+##contig=<ID=KI270383.1,length=1750>
+##contig=<ID=KI270384.1,length=1658>
+##contig=<ID=KI270330.1,length=1652>
+##contig=<ID=KI270372.1,length=1650>
+##contig=<ID=KI270548.1,length=1599>
+##contig=<ID=KI270580.1,length=1553>
+##contig=<ID=KI270387.1,length=1537>
+##contig=<ID=KI270391.1,length=1484>
+##contig=<ID=KI270305.1,length=1472>
+##contig=<ID=KI270373.1,length=1451>
+##contig=<ID=KI270422.1,length=1445>
+##contig=<ID=KI270316.1,length=1444>
+##contig=<ID=KI270340.1,length=1428>
+##contig=<ID=KI270338.1,length=1428>
+##contig=<ID=KI270583.1,length=1400>
+##contig=<ID=KI270334.1,length=1368>
+##contig=<ID=KI270429.1,length=1361>
+##contig=<ID=KI270393.1,length=1308>
+##contig=<ID=KI270516.1,length=1300>
+##contig=<ID=KI270389.1,length=1298>
+##contig=<ID=KI270466.1,length=1233>
+##contig=<ID=KI270388.1,length=1216>
+##contig=<ID=KI270544.1,length=1202>
+##contig=<ID=KI270310.1,length=1201>
+##contig=<ID=KI270412.1,length=1179>
+##contig=<ID=KI270395.1,length=1143>
+##contig=<ID=KI270376.1,length=1136>
+##contig=<ID=KI270337.1,length=1121>
+##contig=<ID=KI270335.1,length=1048>
+##contig=<ID=KI270378.1,length=1048>
+##contig=<ID=KI270379.1,length=1045>
+##contig=<ID=KI270329.1,length=1040>
+##contig=<ID=KI270419.1,length=1029>
+##contig=<ID=KI270336.1,length=1026>
+##contig=<ID=KI270312.1,length=998>
+##contig=<ID=KI270539.1,length=993>
+##contig=<ID=KI270385.1,length=990>
+##contig=<ID=KI270423.1,length=981>
+##contig=<ID=KI270392.1,length=971>
+##contig=<ID=KI270394.1,length=970>
+##INFO=<ID=PROB_FFPE_ARTIFACT,Number=A,Type=Float,Description="Posterior probability for event ffpe_artifact (PHRED)">
+##INFO=<ID=PROB_PRESENT,Number=A,Type=Float,Description="Posterior probability for event present (PHRED)">
+##INFO=<ID=PROB_ARTIFACT,Number=A,Type=Float,Description="Posterior probability for strand bias artifact (PHRED)">
+##INFO=<ID=PROB_ABSENT,Number=A,Type=Float,Description="Posterior probability for not having a variant (PHRED)">
+##FORMAT=<ID=DP,Number=A,Type=Integer,Description="Expected sequencing depth, while considering mapping uncertainty">
+##FORMAT=<ID=OBS,Number=A,Type=String,Description="Posterior odds for alt allele of each fragment as Kass Raftery scores: N=none, B=barely, P=positive, S=strong, V=very strong (lower case if probability for correct mapping of fragment is <95%)">
+##FORMAT=<ID=AF,Number=A,Type=Float,Description="Maximum a posteriori probability estimate of allele frequency">
+##FORMAT=<ID=SB,Number=A,Type=String,Description="Strand bias estimate: + indicates that ALT allele is associated with forward strand, - indicates that ALT allele is associated with reverse strand, - indicates no strand bias.">
+##VEP="v100" time="2020-06-26 20:50:16" cache="resources/vep/cache/homo_sapiens/98_GRCh38" ensembl=100.7e964b7 ensembl-funcgen=100.f0c3948 ensembl-variation=100.b220ff4 ensembl-io=100.f87ae4f 1000genomes="phase3" COSMIC="89" ClinVar="201907" ESP="V2-SSA137" HGMD-PUBLIC="20184" assembly="GRCh38.p13" dbSNP="152" gencode="GENCODE 32" genebuild="2014-07" gnomAD="r2.1" polyphen="2.2.2" regbuild="1.0" sift="sift5.2.2"
+##INFO=<ID=ANN,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|SYMBOL_SOURCE|HGNC_ID|CANONICAL|MANE|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|GENE_PHENO|SIFT|PolyPhen|DOMAINS|miRNA|HGVS_OFFSET|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|AA_AF|EA_AF|gnomAD_AF|gnomAD_AFR_AF|gnomAD_AMR_AF|gnomAD_ASJ_AF|gnomAD_EAS_AF|gnomAD_FIN_AF|gnomAD_NFE_AF|gnomAD_OTH_AF|gnomAD_SAS_AF|MAX_AF|MAX_AF_POPS|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|LoFtool">
+##INFO=<ID=known_E_gnomAD,Number=0,Type=Flag,Description="gnomAD.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_protective,Number=0,Type=Flag,Description="protective.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_CLIN_drug_response,Number=0,Type=Flag,Description="drug response.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=known_CLIN_association,Number=0,Type=Flag,Description="association.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_CLIN_histocompatibility,Number=0,Type=Flag,Description="histocompatibility.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_dbSNP_152,Number=0,Type=Flag,Description="Variants (including SNPs and indels) imported from dbSNP">
+##INFO=<ID=known_MAC,Number=1,Type=Integer,Description="Minor Alelele Count">
+##INFO=<ID=known_MAF,Number=1,Type=Float,Description="Minor Allele Frequency">
+##INFO=<ID=known_E_Hapmap,Number=0,Type=Flag,Description="HapMap.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_ClinVar_201907,Number=0,Type=Flag,Description="Variants of clinical significance imported from ClinVar">
+##INFO=<ID=known_E_Freq,Number=0,Type=Flag,Description="Frequency.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_E_Cited,Number=0,Type=Flag,Description="Cited.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_likely_benign,Number=0,Type=Flag,Description="likely benign.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_TOPMed,Number=0,Type=Flag,Description="TOPMed.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_risk_factor,Number=0,Type=Flag,Description="risk factor.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_HGMD-PUBLIC_20184,Number=0,Type=Flag,Description="Variants from HGMD-PUBLIC dataset December 2018">
+##INFO=<ID=known_CLIN_benign,Number=0,Type=Flag,Description="benign.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_CLIN_other,Number=0,Type=Flag,Description="other.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_ESP,Number=0,Type=Flag,Description="ESP.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_MA,Number=1,Type=String,Description="Minor Allele">
+##INFO=<ID=known_CLIN_likely_pathogenic,Number=0,Type=Flag,Description="likely pathogenic.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_TSA,Number=1,Type=String,Description="Type of sequence alteration. Child of term sequence_alteration as defined by the sequence ontology project.">
+##INFO=<ID=known_CLIN_uncertain_significance,Number=0,Type=Flag,Description="uncertain significance.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_1000G,Number=0,Type=Flag,Description="1000Genomes.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_E_Multiple_observations,Number=0,Type=Flag,Description="Multiple_observations.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_COSMIC_89,Number=0,Type=Flag,Description="Somatic mutations found in human cancers from the COSMIC catalogue">
+##INFO=<ID=known_CLIN_pathogenic,Number=0,Type=Flag,Description="pathogenic.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_ESP_20141103,Number=0,Type=Flag,Description="Data from NHLBI ESP version v.0.0.30. The goal of the NHLBI GO Exome Sequencing Project is to discover novel genes and mechanisms contributing to heart, lung and blood disorders by sequencing the protein coding regions of the human genome.">
+##INFO=<ID=known_CLIN_confers_sensitivity,Number=0,Type=Flag,Description="confers sensitivity.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_Phenotype_or_Disease,Number=0,Type=Flag,Description="Phenotype_or_Disease.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_E_ExAC,Number=0,Type=Flag,Description="ExAC.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_not_provided,Number=0,Type=Flag,Description="not provided.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=dgiDB_drugs,Number=.,Type=String,Description="Combination of gene, drug, interaction types extracted from dgiDB. Each combination is pipe-seperated annotated as GENE|DRUG|TYPE">
+##vembraneVersion=0.1.0
+##vembraneCmd=vembrane test.vcf 'ANN["IMPACT"] == "MODERATE"" --vep
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	tumor
+1	26760988	.	ACCT	CCCC	.	.	SVLEN=.;PROB_ABSENT=21.2691;PROB_ARTIFACT=0.244531;PROB_FFPE_ARTIFACT=15.1855;PROB_PRESENT=17.6998;ANN=CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000324856|protein_coding|5/20||ENST00000324856.13:c.2053_2056delinsCCCC|ENSP00000320485.7:p.Thr685_Ser686delinsProPro|2442-2445|2053-2056|685-686|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|YES|NM_006015.6|1|P3|CCDS285.1|ENSP00000320485|O14497||UPI0000167B91|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000374152|protein_coding|4/19||ENST00000374152.7:c.904_907delinsCCCC|ENSP00000363267.2:p.Thr302_Ser303delinsProPro|1655-1658|904-907|302-303|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|A2||ENSP00000363267|O14497||UPI00019B21DC|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000430799|protein_coding|5/20||ENST00000430799.7:c.904_907delinsCCCC|ENSP00000390317.3:p.Thr302_Ser303delinsProPro|1298-1301|904-907|302-303|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|A2||ENSP00000390317||H0Y488|UPI0007E52D4F|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000457599|protein_coding|5/20||ENST00000457599.6:c.2053_2056delinsCCCC|ENSP00000387636.2:p.Thr685_Ser686delinsProPro|2053-2056|2053-2056|685-686|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|A2|CCDS44091.1|ENSP00000387636|O14497||UPI0000161967|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000615191|protein_coding|4/20||ENST00000615191.4:c.904_907delinsCCCC|ENSP00000478955.1:p.Thr302_Ser303delinsProPro|1187-1190|904-907|302-303|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|||ENSP00000478955||A0A087WUV6|UPI0004E4CD03|1|||PANTHER:PTHR12656:SF12&PANTHER:PTHR12656&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000636219|protein_coding|4/19||ENST00000636219.1:c.910_913delinsCCCC|ENSP00000489842.1:p.Thr304_Ser305delinsProPro|910-913|910-913|304-305|TS/PP|ACCTcc/CCCCcc|||1|cds_start_NF|substitution|HGNC|HGNC:11110|||5|||ENSP00000489842||A0A1B0GTU5|UPI0007E52AD1|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215;dgiDB_drugs=ARID1A|CHEMBL3287735|.,ARID1A|DASATINIB|.,ARID1A|TRASTUZUMAB|.	DP:AF:OBS:SB	198:0:97N+91N-8P-1V-1S-:-

--- a/tests/testcases/test09/test.vcf
+++ b/tests/testcases/test09/test.vcf
@@ -1,0 +1,244 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##contig=<ID=1,length=248956422>
+##contig=<ID=10,length=133797422>
+##contig=<ID=11,length=135086622>
+##contig=<ID=12,length=133275309>
+##contig=<ID=13,length=114364328>
+##contig=<ID=14,length=107043718>
+##contig=<ID=15,length=101991189>
+##contig=<ID=16,length=90338345>
+##contig=<ID=17,length=83257441>
+##contig=<ID=18,length=80373285>
+##contig=<ID=19,length=58617616>
+##contig=<ID=2,length=242193529>
+##contig=<ID=20,length=64444167>
+##contig=<ID=21,length=46709983>
+##contig=<ID=22,length=50818468>
+##contig=<ID=3,length=198295559>
+##contig=<ID=4,length=190214555>
+##contig=<ID=5,length=181538259>
+##contig=<ID=6,length=170805979>
+##contig=<ID=7,length=159345973>
+##contig=<ID=8,length=145138636>
+##contig=<ID=9,length=138394717>
+##contig=<ID=MT,length=16569>
+##contig=<ID=X,length=156040895>
+##contig=<ID=Y,length=57227415>
+##contig=<ID=KI270728.1,length=1872759>
+##contig=<ID=KI270727.1,length=448248>
+##contig=<ID=KI270442.1,length=392061>
+##contig=<ID=KI270729.1,length=280839>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=KI270743.1,length=210658>
+##contig=<ID=GL000008.2,length=209709>
+##contig=<ID=GL000009.2,length=201709>
+##contig=<ID=KI270747.1,length=198735>
+##contig=<ID=KI270722.1,length=194050>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=KI270742.1,length=186739>
+##contig=<ID=GL000205.2,length=185591>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=KI270736.1,length=181920>
+##contig=<ID=KI270733.1,length=179772>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=KI270719.1,length=176845>
+##contig=<ID=GL000216.2,length=176608>
+##contig=<ID=KI270712.1,length=176043>
+##contig=<ID=KI270706.1,length=175055>
+##contig=<ID=KI270725.1,length=172810>
+##contig=<ID=KI270744.1,length=168472>
+##contig=<ID=KI270734.1,length=165050>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=KI270715.1,length=161471>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=KI270749.1,length=158759>
+##contig=<ID=KI270741.1,length=157432>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=KI270716.1,length=153799>
+##contig=<ID=KI270731.1,length=150754>
+##contig=<ID=KI270751.1,length=150742>
+##contig=<ID=KI270750.1,length=148850>
+##contig=<ID=KI270519.1,length=138126>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=KI270708.1,length=127682>
+##contig=<ID=KI270730.1,length=112551>
+##contig=<ID=KI270438.1,length=112505>
+##contig=<ID=KI270737.1,length=103838>
+##contig=<ID=KI270721.1,length=100316>
+##contig=<ID=KI270738.1,length=99375>
+##contig=<ID=KI270748.1,length=93321>
+##contig=<ID=KI270435.1,length=92983>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=KI270538.1,length=91309>
+##contig=<ID=KI270756.1,length=79590>
+##contig=<ID=KI270739.1,length=73985>
+##contig=<ID=KI270757.1,length=71251>
+##contig=<ID=KI270709.1,length=66860>
+##contig=<ID=KI270746.1,length=66486>
+##contig=<ID=KI270753.1,length=62944>
+##contig=<ID=KI270589.1,length=44474>
+##contig=<ID=KI270726.1,length=43739>
+##contig=<ID=KI270735.1,length=42811>
+##contig=<ID=KI270711.1,length=42210>
+##contig=<ID=KI270745.1,length=41891>
+##contig=<ID=KI270714.1,length=41717>
+##contig=<ID=KI270732.1,length=41543>
+##contig=<ID=KI270713.1,length=40745>
+##contig=<ID=KI270754.1,length=40191>
+##contig=<ID=KI270710.1,length=40176>
+##contig=<ID=KI270717.1,length=40062>
+##contig=<ID=KI270724.1,length=39555>
+##contig=<ID=KI270720.1,length=39050>
+##contig=<ID=KI270723.1,length=38115>
+##contig=<ID=KI270718.1,length=38054>
+##contig=<ID=KI270317.1,length=37690>
+##contig=<ID=KI270740.1,length=37240>
+##contig=<ID=KI270755.1,length=36723>
+##contig=<ID=KI270707.1,length=32032>
+##contig=<ID=KI270579.1,length=31033>
+##contig=<ID=KI270752.1,length=27745>
+##contig=<ID=KI270512.1,length=22689>
+##contig=<ID=KI270322.1,length=21476>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=KI270311.1,length=12399>
+##contig=<ID=KI270366.1,length=8320>
+##contig=<ID=KI270511.1,length=8127>
+##contig=<ID=KI270448.1,length=7992>
+##contig=<ID=KI270521.1,length=7642>
+##contig=<ID=KI270581.1,length=7046>
+##contig=<ID=KI270582.1,length=6504>
+##contig=<ID=KI270515.1,length=6361>
+##contig=<ID=KI270588.1,length=6158>
+##contig=<ID=KI270591.1,length=5796>
+##contig=<ID=KI270522.1,length=5674>
+##contig=<ID=KI270507.1,length=5353>
+##contig=<ID=KI270590.1,length=4685>
+##contig=<ID=KI270584.1,length=4513>
+##contig=<ID=KI270320.1,length=4416>
+##contig=<ID=KI270382.1,length=4215>
+##contig=<ID=KI270468.1,length=4055>
+##contig=<ID=KI270467.1,length=3920>
+##contig=<ID=KI270362.1,length=3530>
+##contig=<ID=KI270517.1,length=3253>
+##contig=<ID=KI270593.1,length=3041>
+##contig=<ID=KI270528.1,length=2983>
+##contig=<ID=KI270587.1,length=2969>
+##contig=<ID=KI270364.1,length=2855>
+##contig=<ID=KI270371.1,length=2805>
+##contig=<ID=KI270333.1,length=2699>
+##contig=<ID=KI270374.1,length=2656>
+##contig=<ID=KI270411.1,length=2646>
+##contig=<ID=KI270414.1,length=2489>
+##contig=<ID=KI270510.1,length=2415>
+##contig=<ID=KI270390.1,length=2387>
+##contig=<ID=KI270375.1,length=2378>
+##contig=<ID=KI270420.1,length=2321>
+##contig=<ID=KI270509.1,length=2318>
+##contig=<ID=KI270315.1,length=2276>
+##contig=<ID=KI270302.1,length=2274>
+##contig=<ID=KI270518.1,length=2186>
+##contig=<ID=KI270530.1,length=2168>
+##contig=<ID=KI270304.1,length=2165>
+##contig=<ID=KI270418.1,length=2145>
+##contig=<ID=KI270424.1,length=2140>
+##contig=<ID=KI270417.1,length=2043>
+##contig=<ID=KI270508.1,length=1951>
+##contig=<ID=KI270303.1,length=1942>
+##contig=<ID=KI270381.1,length=1930>
+##contig=<ID=KI270529.1,length=1899>
+##contig=<ID=KI270425.1,length=1884>
+##contig=<ID=KI270396.1,length=1880>
+##contig=<ID=KI270363.1,length=1803>
+##contig=<ID=KI270386.1,length=1788>
+##contig=<ID=KI270465.1,length=1774>
+##contig=<ID=KI270383.1,length=1750>
+##contig=<ID=KI270384.1,length=1658>
+##contig=<ID=KI270330.1,length=1652>
+##contig=<ID=KI270372.1,length=1650>
+##contig=<ID=KI270548.1,length=1599>
+##contig=<ID=KI270580.1,length=1553>
+##contig=<ID=KI270387.1,length=1537>
+##contig=<ID=KI270391.1,length=1484>
+##contig=<ID=KI270305.1,length=1472>
+##contig=<ID=KI270373.1,length=1451>
+##contig=<ID=KI270422.1,length=1445>
+##contig=<ID=KI270316.1,length=1444>
+##contig=<ID=KI270340.1,length=1428>
+##contig=<ID=KI270338.1,length=1428>
+##contig=<ID=KI270583.1,length=1400>
+##contig=<ID=KI270334.1,length=1368>
+##contig=<ID=KI270429.1,length=1361>
+##contig=<ID=KI270393.1,length=1308>
+##contig=<ID=KI270516.1,length=1300>
+##contig=<ID=KI270389.1,length=1298>
+##contig=<ID=KI270466.1,length=1233>
+##contig=<ID=KI270388.1,length=1216>
+##contig=<ID=KI270544.1,length=1202>
+##contig=<ID=KI270310.1,length=1201>
+##contig=<ID=KI270412.1,length=1179>
+##contig=<ID=KI270395.1,length=1143>
+##contig=<ID=KI270376.1,length=1136>
+##contig=<ID=KI270337.1,length=1121>
+##contig=<ID=KI270335.1,length=1048>
+##contig=<ID=KI270378.1,length=1048>
+##contig=<ID=KI270379.1,length=1045>
+##contig=<ID=KI270329.1,length=1040>
+##contig=<ID=KI270419.1,length=1029>
+##contig=<ID=KI270336.1,length=1026>
+##contig=<ID=KI270312.1,length=998>
+##contig=<ID=KI270539.1,length=993>
+##contig=<ID=KI270385.1,length=990>
+##contig=<ID=KI270423.1,length=981>
+##contig=<ID=KI270392.1,length=971>
+##contig=<ID=KI270394.1,length=970>
+##INFO=<ID=PROB_FFPE_ARTIFACT,Number=A,Type=Float,Description="Posterior probability for event ffpe_artifact (PHRED)">
+##INFO=<ID=PROB_PRESENT,Number=A,Type=Float,Description="Posterior probability for event present (PHRED)">
+##INFO=<ID=PROB_ARTIFACT,Number=A,Type=Float,Description="Posterior probability for strand bias artifact (PHRED)">
+##INFO=<ID=PROB_ABSENT,Number=A,Type=Float,Description="Posterior probability for not having a variant (PHRED)">
+##FORMAT=<ID=DP,Number=A,Type=Integer,Description="Expected sequencing depth, while considering mapping uncertainty">
+##FORMAT=<ID=OBS,Number=A,Type=String,Description="Posterior odds for alt allele of each fragment as Kass Raftery scores: N=none, B=barely, P=positive, S=strong, V=very strong (lower case if probability for correct mapping of fragment is <95%)">
+##FORMAT=<ID=AF,Number=A,Type=Float,Description="Maximum a posteriori probability estimate of allele frequency">
+##FORMAT=<ID=SB,Number=A,Type=String,Description="Strand bias estimate: + indicates that ALT allele is associated with forward strand, - indicates that ALT allele is associated with reverse strand, - indicates no strand bias.">
+##VEP="v100" time="2020-06-26 20:50:16" cache="resources/vep/cache/homo_sapiens/98_GRCh38" ensembl=100.7e964b7 ensembl-funcgen=100.f0c3948 ensembl-variation=100.b220ff4 ensembl-io=100.f87ae4f 1000genomes="phase3" COSMIC="89" ClinVar="201907" ESP="V2-SSA137" HGMD-PUBLIC="20184" assembly="GRCh38.p13" dbSNP="152" gencode="GENCODE 32" genebuild="2014-07" gnomAD="r2.1" polyphen="2.2.2" regbuild="1.0" sift="sift5.2.2"
+##INFO=<ID=ANN,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|SYMBOL_SOURCE|HGNC_ID|CANONICAL|MANE|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|GENE_PHENO|SIFT|PolyPhen|DOMAINS|miRNA|HGVS_OFFSET|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|AA_AF|EA_AF|gnomAD_AF|gnomAD_AFR_AF|gnomAD_AMR_AF|gnomAD_ASJ_AF|gnomAD_EAS_AF|gnomAD_FIN_AF|gnomAD_NFE_AF|gnomAD_OTH_AF|gnomAD_SAS_AF|MAX_AF|MAX_AF_POPS|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|LoFtool">
+##INFO=<ID=known_E_gnomAD,Number=0,Type=Flag,Description="gnomAD.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_protective,Number=0,Type=Flag,Description="protective.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_CLIN_drug_response,Number=0,Type=Flag,Description="drug response.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=known_CLIN_association,Number=0,Type=Flag,Description="association.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_CLIN_histocompatibility,Number=0,Type=Flag,Description="histocompatibility.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_dbSNP_152,Number=0,Type=Flag,Description="Variants (including SNPs and indels) imported from dbSNP">
+##INFO=<ID=known_MAC,Number=1,Type=Integer,Description="Minor Alelele Count">
+##INFO=<ID=known_MAF,Number=1,Type=Float,Description="Minor Allele Frequency">
+##INFO=<ID=known_E_Hapmap,Number=0,Type=Flag,Description="HapMap.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_ClinVar_201907,Number=0,Type=Flag,Description="Variants of clinical significance imported from ClinVar">
+##INFO=<ID=known_E_Freq,Number=0,Type=Flag,Description="Frequency.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_E_Cited,Number=0,Type=Flag,Description="Cited.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_likely_benign,Number=0,Type=Flag,Description="likely benign.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_TOPMed,Number=0,Type=Flag,Description="TOPMed.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_risk_factor,Number=0,Type=Flag,Description="risk factor.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_HGMD-PUBLIC_20184,Number=0,Type=Flag,Description="Variants from HGMD-PUBLIC dataset December 2018">
+##INFO=<ID=known_CLIN_benign,Number=0,Type=Flag,Description="benign.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_CLIN_other,Number=0,Type=Flag,Description="other.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_ESP,Number=0,Type=Flag,Description="ESP.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_MA,Number=1,Type=String,Description="Minor Allele">
+##INFO=<ID=known_CLIN_likely_pathogenic,Number=0,Type=Flag,Description="likely pathogenic.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_TSA,Number=1,Type=String,Description="Type of sequence alteration. Child of term sequence_alteration as defined by the sequence ontology project.">
+##INFO=<ID=known_CLIN_uncertain_significance,Number=0,Type=Flag,Description="uncertain significance.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_1000G,Number=0,Type=Flag,Description="1000Genomes.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_E_Multiple_observations,Number=0,Type=Flag,Description="Multiple_observations.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_COSMIC_89,Number=0,Type=Flag,Description="Somatic mutations found in human cancers from the COSMIC catalogue">
+##INFO=<ID=known_CLIN_pathogenic,Number=0,Type=Flag,Description="pathogenic.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_ESP_20141103,Number=0,Type=Flag,Description="Data from NHLBI ESP version v.0.0.30. The goal of the NHLBI GO Exome Sequencing Project is to discover novel genes and mechanisms contributing to heart, lung and blood disorders by sequencing the protein coding regions of the human genome.">
+##INFO=<ID=known_CLIN_confers_sensitivity,Number=0,Type=Flag,Description="confers sensitivity.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=known_E_Phenotype_or_Disease,Number=0,Type=Flag,Description="Phenotype_or_Disease.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_E_ExAC,Number=0,Type=Flag,Description="ExAC.https://www.ensembl.org/info/genome/variation/prediction/variant_quality.html#evidence_status">
+##INFO=<ID=known_CLIN_not_provided,Number=0,Type=Flag,Description="not provided.https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html#clin_significance">
+##INFO=<ID=dgiDB_drugs,Number=.,Type=String,Description="Combination of gene, drug, interaction types extracted from dgiDB. Each combination is pipe-seperated annotated as GENE|DRUG|TYPE">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	tumor
+1	26696985	rs1283126655	C	T	.	.	SVLEN=.;PROB_ARTIFACT=8.16365;PROB_FFPE_ARTIFACT=inf;PROB_PRESENT=1.15636;PROB_ABSENT=10.908;ANN=T|synonymous_variant|LOW|ARID1A|ENSG00000117713|Transcript|ENST00000324856|protein_coding|1/20||ENST00000324856.13:c.582C>T|ENSP00000320485.7:p.Pro194%3D|971|582|194|P|ccC/ccT|rs1283126655||1||SNV|HGNC|HGNC:11110|YES|NM_006015.6|1|P3|CCDS285.1|ENSP00000320485|O14497||UPI0000167B91|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite|||||||||||0|0|0|0|0|0|0|0|0|0|gnomAD_AFR&gnomAD_AMR&gnomAD_ASJ&gnomAD_EAS&gnomAD_FIN&gnomAD_NFE&gnomAD_OTH&gnomAD_SAS|||||||||0.0215,T|intron_variant|MODIFIER|ARID1A|ENSG00000117713|Transcript|ENST00000430799|protein_coding||1/19|ENST00000430799.7:c.-13+3368C>T|||||||rs1283126655||1||SNV|HGNC|HGNC:11110|||5|A2||ENSP00000390317||H0Y488|UPI0007E52D4F|1||||||||||||||0|0|0|0|0|0|0|0|0|0|gnomAD_AFR&gnomAD_AMR&gnomAD_ASJ&gnomAD_EAS&gnomAD_FIN&gnomAD_NFE&gnomAD_OTH&gnomAD_SAS|||||||||0.0215,T|synonymous_variant|LOW|ARID1A|ENSG00000117713|Transcript|ENST00000457599|protein_coding|1/20||ENST00000457599.6:c.582C>T|ENSP00000387636.2:p.Pro194%3D|582|582|194|P|ccC/ccT|rs1283126655||1||SNV|HGNC|HGNC:11110|||5|A2|CCDS44091.1|ENSP00000387636|O14497||UPI0000161967|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite|||||||||||0|0|0|0|0|0|0|0|0|0|gnomAD_AFR&gnomAD_AMR&gnomAD_ASJ&gnomAD_EAS&gnomAD_FIN&gnomAD_NFE&gnomAD_OTH&gnomAD_SAS|||||||||0.0215,T|upstream_gene_variant|MODIFIER|AL512408.1|ENSG00000260063|Transcript|ENST00000569378|lncRNA||||||||||rs1283126655|2854|-1||SNV|Clone_based_ensembl_gene||YES|||||||||||||||||||||||0|0|0|0|0|0|0|0|0|0|gnomAD_AFR&gnomAD_AMR&gnomAD_ASJ&gnomAD_EAS&gnomAD_FIN&gnomAD_NFE&gnomAD_OTH&gnomAD_SAS|||||||||,T|intron_variant|MODIFIER|ARID1A|ENSG00000117713|Transcript|ENST00000637465|protein_coding||1/2|ENST00000637465.1:c.-13+885C>T|||||||rs1283126655||1|cds_end_NF|SNV|HGNC|HGNC:11110|||5|||ENSP00000490650||A0A1B0GVT5|UPI0007E52CCF|1||||||||||||||0|0|0|0|0|0|0|0|0|0|gnomAD_AFR&gnomAD_AMR&gnomAD_ASJ&gnomAD_EAS&gnomAD_FIN&gnomAD_NFE&gnomAD_OTH&gnomAD_SAS|||||||||0.0215,T|regulatory_region_variant|MODIFIER|||RegulatoryFeature|ENSR00000250867|promoter||||||||||rs1283126655||||SNV||||||||||||||||||||||||||0|0|0|0|0|0|0|0|0|0|gnomAD_AFR&gnomAD_AMR&gnomAD_ASJ&gnomAD_EAS&gnomAD_FIN&gnomAD_NFE&gnomAD_OTH&gnomAD_SAS|||||||||;known_AA=C;known_E_Freq;known_E_TOPMed;known_E_gnomAD;known_TSA=SNV;known_dbSNP_152;dgiDB_drugs=|.|.,AL512408.1|.|.,ARID1A|CHEMBL3287735|.,ARID1A|DASATINIB|.,ARID1A|TRASTUZUMAB|.	DP:AF:OBS:SB	35:0.0571429:17N+16N-1V-1S+:.
+1	26760988	.	ACCT	CCCC	.	.	SVLEN=.;PROB_ABSENT=21.2691;PROB_ARTIFACT=0.244531;PROB_FFPE_ARTIFACT=15.1855;PROB_PRESENT=17.6998;ANN=CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000324856|protein_coding|5/20||ENST00000324856.13:c.2053_2056delinsCCCC|ENSP00000320485.7:p.Thr685_Ser686delinsProPro|2442-2445|2053-2056|685-686|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|YES|NM_006015.6|1|P3|CCDS285.1|ENSP00000320485|O14497||UPI0000167B91|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000374152|protein_coding|4/19||ENST00000374152.7:c.904_907delinsCCCC|ENSP00000363267.2:p.Thr302_Ser303delinsProPro|1655-1658|904-907|302-303|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|A2||ENSP00000363267|O14497||UPI00019B21DC|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000430799|protein_coding|5/20||ENST00000430799.7:c.904_907delinsCCCC|ENSP00000390317.3:p.Thr302_Ser303delinsProPro|1298-1301|904-907|302-303|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|A2||ENSP00000390317||H0Y488|UPI0007E52D4F|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000457599|protein_coding|5/20||ENST00000457599.6:c.2053_2056delinsCCCC|ENSP00000387636.2:p.Thr685_Ser686delinsProPro|2053-2056|2053-2056|685-686|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|A2|CCDS44091.1|ENSP00000387636|O14497||UPI0000161967|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000615191|protein_coding|4/20||ENST00000615191.4:c.904_907delinsCCCC|ENSP00000478955.1:p.Thr302_Ser303delinsProPro|1187-1190|904-907|302-303|TS/PP|ACCTcc/CCCCcc|||1||substitution|HGNC|HGNC:11110|||5|||ENSP00000478955||A0A087WUV6|UPI0004E4CD03|1|||PANTHER:PTHR12656:SF12&PANTHER:PTHR12656&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|missense_variant|MODERATE|ARID1A|ENSG00000117713|Transcript|ENST00000636219|protein_coding|4/19||ENST00000636219.1:c.910_913delinsCCCC|ENSP00000489842.1:p.Thr304_Ser305delinsProPro|910-913|910-913|304-305|TS/PP|ACCTcc/CCCCcc|||1|cds_start_NF|substitution|HGNC|HGNC:11110|||5|||ENSP00000489842||A0A1B0GTU5|UPI0007E52AD1|1|||PANTHER:PTHR12656&PANTHER:PTHR12656:SF12&MobiDB_lite:mobidb-lite&MobiDB_lite:mobidb-lite||||||||||||||||||||||||||||||0.0215,CCCC|upstream_gene_variant|MODIFIER|ARID1A|ENSG00000117713|Transcript|ENST00000636422|retained_intron|||||||||||3274|1||substitution|HGNC|HGNC:11110|||5|||||||1|||||||||||||||||||||||||||||||||0.0215,CCCC|non_coding_transcript_exon_variant|MODIFIER|ARID1A|ENSG00000117713|Transcript|ENST00000636958|lncRNA|2/6||ENST00000636958.1:n.423_426delinsCCCC||423-426|||||||1||substitution|HGNC|HGNC:11110|||5|||||||1|||||||||||||||||||||||||||||||||0.0215;dgiDB_drugs=ARID1A|CHEMBL3287735|.,ARID1A|DASATINIB|.,ARID1A|TRASTUZUMAB|.	DP:AF:OBS:SB	198:0:97N+91N-8P-1V-1S-:-


### PR DESCRIPTION
This PR adds a flag for parsing variant files annotated by VEP.
This is necessary as VEP does not use quotation marks in the description of the ANN-field.
Therefore, the separator get's turned into `:` instead of `'`.
To avoid using flag we could alternatively check if the description contains the string "Ensembl VEP".

The INFO row created bei VEP looks as following:
`##INFO=<ID=ANN,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|SYMBOL_SOURCE|HGNC_ID|CANONICAL|MANE|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|GENE_PHENO|SIFT|PolyPhen|DOMAINS|miRNA|HGVS_OFFSET|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|AA_AF|EA_AF|gnomAD_AF|gnomAD_AFR_AF|gnomAD_AMR_AF|gnomAD_ASJ_AF|gnomAD_EAS_AF|gnomAD_FIN_AF|gnomAD_NFE_AF|gnomAD_OTH_AF|gnomAD_SAS_AF|MAX_AF|MAX_AF_POPS|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|LoFtool">
`

