### PR TITLE
Optional dot notation

### DIFF
--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -37,11 +37,38 @@ globals_whitelist = {
 }
 
 
+class Map(dict):
+    def __init__(self, *args, **kwargs):
+        super(Map, self).__init__(*args, **kwargs)
+        for arg in args:
+            if isinstance(arg, dict):
+                for k, v in arg.iteritems():
+                    self[k] = v
+        if kwargs:
+            for k, v in kwargs.iteritems():
+                self[k] = v
+    def __getattr__(self, attr):
+        return self.get(attr)
+    def __setattr__(self, key, value):
+        self.__setitem__(key, value)
+    def __setitem__(self, key, value):
+        super(Map, self).__setitem__(key, value)
+        self.__dict__.update({key: value})
+    def __delattr__(self, item):
+        self.__delitem__(item)
+    def __delitem__(self, key):
+        super(Map, self).__delitem__(key)
+        del self.__dict__[key]
+
+
 class Sample:
     def __init__(self, record_idx: int, sample: str, format_data: Dict[str, Any]):
         self._record_idx = record_idx
         self._sample = sample
         self._data = format_data
+
+    def __getattr__(self, attr):
+        return self.__getitem__(attr)
 
     def __getitem__(self, item):
         try:
@@ -55,6 +82,9 @@ class Format:
         self._record_idx = record_idx
         self._sample_formats = sample_formats
 
+    def __getattr__(self, attr):
+        return self.__getitem__(attr)
+
     def __getitem__(self, item):
         try:
             return self._sample_formats[item]
@@ -66,6 +96,9 @@ class Annotation:
     def __init__(self, record_idx: int, annotation_data: Dict[str, Any]):
         self._record_idx = record_idx
         self._data = annotation_data
+
+    def __getattr__(self, attr):
+        return self.__getitem__(attr)
 
     def __getitem__(self, item):
         try:

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -36,6 +36,7 @@ globals_whitelist = {
     **{name: mod for name, mod in vars(math).items() if not name.startswith("__")},
 }
 
+
 class Sample:
     def __init__(self, record_idx: int, sample: str, format_data: Dict[str, Any]):
         self._record_idx = record_idx

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -47,15 +47,20 @@ class Map(dict):
         if kwargs:
             for k, v in kwargs.iteritems():
                 self[k] = v
+
     def __getattr__(self, attr):
         return self.get(attr)
+
     def __setattr__(self, key, value):
         self.__setitem__(key, value)
+
     def __setitem__(self, key, value):
         super(Map, self).__setitem__(key, value)
         self.__dict__.update({key: value})
+
     def __delattr__(self, item):
         self.__delitem__(item)
+
     def __delitem__(self, key):
         super(Map, self).__delitem__(key)
         del self.__dict__[key]

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -36,36 +36,6 @@ globals_whitelist = {
     **{name: mod for name, mod in vars(math).items() if not name.startswith("__")},
 }
 
-
-class Map(dict):
-    def __init__(self, *args, **kwargs):
-        super(Map, self).__init__(*args, **kwargs)
-        for arg in args:
-            if isinstance(arg, dict):
-                for k, v in arg.iteritems():
-                    self[k] = v
-        if kwargs:
-            for k, v in kwargs.iteritems():
-                self[k] = v
-
-    def __getattr__(self, attr):
-        return self.get(attr)
-
-    def __setattr__(self, key, value):
-        self.__setitem__(key, value)
-
-    def __setitem__(self, key, value):
-        super(Map, self).__setitem__(key, value)
-        self.__dict__.update({key: value})
-
-    def __delattr__(self, item):
-        self.__delitem__(item)
-
-    def __delitem__(self, key):
-        super(Map, self).__delitem__(key)
-        del self.__dict__[key]
-
-
 class Sample:
     def __init__(self, record_idx: int, sample: str, format_data: Dict[str, Any]):
         self._record_idx = record_idx


### PR DESCRIPTION
Just a small change, that allows to also use dot notation to access the fields, so that

`ANN.Annotation_Impact`

instead of
`
ANN["Annotation_Impact"]`

becomes possible. I am aware, that the last should be the default way of doing it, since the name must not be a valid python identifier.