### PR TITLE
Return empty list for list fields

### DIFF
--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -125,7 +125,6 @@ KNOWN_ANN_TYPE_MAP_SNPEFF = {
         "ERRORS / WARNINGS / INFO",
         lambda x: [v.strip() for v in x.split("/")],
     ),
-    "CLIN_SIG": ("CLIN_SIG", lambda x: [v.strip() for v in x.split("&")]),
 }
 
 KNOWN_ANN_TYPE_MAP_VEP = {

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -143,6 +143,7 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     "cDNA_position": ("cDNA_position", str),
     "CDS_position": ("CDS_position", str),
     "Protein_position": ("Protein_position", str),
+    "CLIN_SIG": ("CLIN_SIG", lambda x: [v.strip() for v in x.split("&")]),
 }
 
 KNOWN_ANN_TYPE_MAP = {**KNOWN_ANN_TYPE_MAP_SNPEFF, **KNOWN_ANN_TYPE_MAP_VEP}

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -68,6 +68,8 @@ def type_ann(
         new_key, value_func = KNOWN_ANN_TYPE_MAP.get(key, (key, try_auto_type))
         return new_key, value_func(value)
     else:
+        if key == "CLIN_SIG":
+            return (key, [])
         return (key, NA)
 
 

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -64,13 +64,12 @@ def try_auto_type(value: str) -> AutoType:
 def type_ann(
     key: str, value: str
 ) -> Tuple[str, Union[IntFloatStr, Iterable["IntFloatStr"], NoValue]]:
+    type_map = KnownAnnTypeList() if key in ["CLIN_SIG"] else KnownAnnType()
     if value:
-        new_key, value_func = KNOWN_ANN_TYPE_MAP.get(key, (key, try_auto_type))
+        new_key, value_func = type_map.get_value_func(key)
         return new_key, value_func(value)
     else:
-        if key == "CLIN_SIG":
-            return (key, [])
-        return (key, NA)
+        return (key, type_map.na_type())
 
 
 def type_int_pair(value: str) -> Union[List[int], NoValue]:
@@ -145,4 +144,18 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     "CLIN_SIG": ("CLIN_SIG", lambda x: [v.strip() for v in x.split("&")]),
 }
 
-KNOWN_ANN_TYPE_MAP = {**KNOWN_ANN_TYPE_MAP_SNPEFF, **KNOWN_ANN_TYPE_MAP_VEP}
+
+class KnownAnnType:
+    def __init__(self):
+        self.map = {**KNOWN_ANN_TYPE_MAP_SNPEFF, **KNOWN_ANN_TYPE_MAP_VEP}
+
+    def get_value_func(self, key):
+        return self.map.get(key, (key, try_auto_type))
+
+    def na_type(self):
+        return NA
+
+
+class KnownAnnTypeList(KnownAnnType):
+    def na_type(self):
+        return []


### PR DESCRIPTION
Currently filtering for elements in list fields like `CLIN_SIG` does not perform well in case there is no entry for the field.
This is because we currently return NA if a key has no value/entry.
While this works for most fields expression like `"'unknown_significance' in ANN['CLIN_SIG']"` may fail.

This PR justs includes a quick work around for this specific field but we should implement a more general solution.
Setting up a list containing fields being list-types would be a solution.
But setting up more and more lists and dictionaries which need to be manually managed makes this less robust.