### PR TITLE
ANN: Ditch auto typing (default to str), wrap dicts in AnnotationTyper class

### DIFF
--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -14,7 +14,7 @@ from typing import Iterator, List, Dict, Any
 import yaml
 from pysam import VariantFile, VariantRecord, VariantHeader
 
-from vembrane.ann_types import type_ann, NA, type_info
+from vembrane.ann_types import NA, type_info, ANN_TYPER
 from vembrane.errors import (
     UnknownAnnotation,
     UnknownInfoField,
@@ -100,7 +100,7 @@ def eval_expression(
         idx,
         dict(
             map(
-                lambda v: type_ann(v[0], v[1]),
+                lambda v: ANN_TYPER.convert(v[0], v[1]),
                 zip(annotation_keys, parse_annotation_entry(annotation)),
             )
         ),

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -102,6 +102,8 @@ class AnnotationEntry:
 
 class DefaultAnnotationEntry(AnnotationEntry):
     def __init__(self, name: str):
+        # TODO issue INFO: No type conversion information about {name},
+        #  please open an issue here: https://github.com/vembrane/vembrane/issues
         super().__init__(name)
 
 

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -1,4 +1,4 @@
-from typing import Union, Iterable, List, Tuple
+from typing import Union, Iterable, Tuple, Dict, Callable, Any
 
 
 class NoValue:
@@ -37,45 +37,6 @@ class InfoTuple:
 
 
 IntFloatStr = Union[int, float, str]
-AutoType = Union[IntFloatStr, "AutoType", Iterable["AutoType"]]
-
-
-def try_auto_type(value: str) -> AutoType:
-    if not value:
-        return None
-    for t in (int, float):  # try int and float first
-        try:
-            return t(value)
-        except ValueError:
-            continue
-    for sep in ("/", "&"):  # if that didn't work, try splitting at "/" or "&"
-        if sep in value:  # check if the value contains a separator
-            # and re-try auto typing on every element of the value split by sep
-            values = list(map(try_auto_type, map(str.strip, value.split(sep))))
-            if values and all(values):  # if none of these valeus is None
-                return values  # return the list of autotyped values
-            else:
-                return str(value)  # otherwise return the original string
-        else:  # try the next separator
-            continue
-    return str(value)  # if all else fails, return the original string
-
-
-def type_ann(
-    key: str, value: str
-) -> Tuple[str, Union[IntFloatStr, Iterable["IntFloatStr"], NoValue]]:
-    if value:
-        new_key, value_func = KNOWN_ANN_TYPE_MAP.get(key, (key, try_auto_type))
-        return new_key, value_func(value)
-    else:
-        return (key, NA)
-
-
-def type_int_pair(value: str) -> Union[List[int], NoValue]:
-    if value:
-        return [int(v.strip()) for v in value.split("/")]
-    else:
-        return NA
 
 
 def type_info(value):
@@ -92,9 +53,20 @@ class PosLength:
         self.length = length
 
     @classmethod
-    def from_str(cls, value: str) -> "PosLength":
-        pos, length = type_int_pair(value)
+    def from_snpeff_str(cls, value: str) -> "PosLength":
+        pos, length = [int(v.strip()) for v in value.split("/")]
         return cls(pos, length)
+
+    @classmethod
+    def from_vep_str(cls, value: str) -> "PosLength":
+        start, end = (
+            #  the "-" is optional, so vep either has either start and end position
+            [int(v.strip()) for v in value.split("-")]
+            if "-" in value
+            #  or start position only
+            else [int(value.strip())] * 2
+        )
+        return cls(start, start + end)
 
     def __str__(self):
         return f"(pos: {self.pos}, length: {self.length})"
@@ -103,44 +75,88 @@ class PosLength:
         return self.__str__()
 
 
+def na_func() -> NoValue:
+    return NA
+
+
+AnnotationType = Union[IntFloatStr, Iterable["IntFloatStr"], NoValue]
+
+
+class AnnotationEntry:
+    def __init__(
+        self,
+        name: str,
+        typefunc: Callable[[str], Any] = str,
+        nafunc: Callable[[], Any] = na_func,
+    ):
+        self._name = name
+        self._typefunc = typefunc
+        self._nafunc = nafunc
+
+    def convert(self, value: str) -> Tuple[str, Any]:
+        if value:
+            return self._name, self._typefunc(value)
+        else:
+            return self._name, self._nafunc()
+
+
+class DefaultAnnotationEntry(AnnotationEntry):
+    def __init__(self, name: str):
+        super().__init__(name)
+
+
+class AnnotationTyper:
+    def __init__(self, mapping: Dict[str, AnnotationEntry]):
+        self._mapping = mapping
+
+    def convert(self, key: str, value: str) -> Tuple[str, AnnotationType]:
+
+        return self._mapping.get(key, DefaultAnnotationEntry(key)).convert(value)
+
+
 KNOWN_ANN_TYPE_MAP_SNPEFF = {
-    "Allele": ("Allele", str),
-    "Annotation": ("Annotation", str),
-    "Annotation_Impact": ("Annotation_Impact", str),
-    "Gene_Name": ("Gene_Name", str),
-    "Gene_ID": ("Gene_ID", str),
-    "Feature_Type": ("Feature_Type", str),
-    "Feature_ID": ("Feature_ID", str),
-    "Transcript_BioType": ("Transcript_BioType", str),
-    "Rank": ("Rank", str),
-    "HGVS.c": ("HGVS.c", str),
-    "HGVS.p": ("HGVS.p", str),
-    "cDNA.pos / cDNA.length": ("cDNA", PosLength.from_str),
-    "CDS.pos / CDS.length": ("CDS", PosLength.from_str),
-    "AA.pos / AA.length": ("AA", PosLength.from_str),
-    "Distance": ("Distance", try_auto_type),
-    "ERRORS / WARNINGS / INFO": (
+    "Allele": AnnotationEntry("Allele"),
+    "Annotation": AnnotationEntry("Annotation"),
+    "Annotation_Impact": AnnotationEntry("Annotation_Impact"),
+    "Gene_Name": AnnotationEntry("Gene_Name"),
+    "Gene_ID": AnnotationEntry("Gene_ID"),
+    "Feature_Type": AnnotationEntry("Feature_Type"),
+    "Feature_ID": AnnotationEntry("Feature_ID"),
+    "Transcript_BioType": AnnotationEntry("Transcript_BioType"),
+    "Rank": AnnotationEntry("Rank"),
+    "HGVS.c": AnnotationEntry("HGVS.c"),
+    "HGVS.p": AnnotationEntry("HGVS.p"),
+    "cDNA.pos / cDNA.length": AnnotationEntry("cDNA", PosLength.from_snpeff_str),
+    "CDS.pos / CDS.length": AnnotationEntry("CDS", PosLength.from_snpeff_str),
+    "AA.pos / AA.length": AnnotationEntry("AA", PosLength.from_snpeff_str),
+    "Distance": AnnotationEntry("Distance", str),
+    "ERRORS / WARNINGS / INFO": AnnotationEntry(
         "ERRORS / WARNINGS / INFO",
         lambda x: [v.strip() for v in x.split("/")],
+        lambda: [],
     ),
-    "CLIN_SIG": ("CLIN_SIG", lambda x: [v.strip() for v in x.split("&")]),
 }
 
 KNOWN_ANN_TYPE_MAP_VEP = {
-    "Allele": ("Allele", str),
-    "Consequence": ("Consequence", str),
-    "IMPACT": ("IMPACT", str),
-    "SYMBOL": ("SYMBOL", str),
-    "Gene": ("Gene", str),
-    "Feature_type": ("Feature_type", str),
-    "Feature": ("Feature", str),
-    "EXON": ("EXON", str),
-    "INTRON": ("INTRON", str),
-    "HGSVc": ("HGSVc", str),
-    "HGSVp": ("HGSVp", str),
-    "cDNA_position": ("cDNA_position", str),
-    "CDS_position": ("CDS_position", str),
-    "Protein_position": ("Protein_position", str),
+    "Allele": AnnotationEntry("Allele"),
+    "Consequence": AnnotationEntry("Consequence"),
+    "IMPACT": AnnotationEntry("IMPACT"),
+    "SYMBOL": AnnotationEntry("SYMBOL"),
+    "Gene": AnnotationEntry("Gene"),
+    "Feature_type": AnnotationEntry("Feature_type"),
+    "Feature": AnnotationEntry("Feature"),
+    "EXON": AnnotationEntry("EXON"),
+    "INTRON": AnnotationEntry("INTRON"),
+    "HGSVc": AnnotationEntry("HGSVc"),
+    "HGSVp": AnnotationEntry("HGSVp"),
+    "cDNA_position": AnnotationEntry("cDNA", PosLength.from_vep_str),
+    "CDS_position": AnnotationEntry("CDS", PosLength.from_vep_str),
+    "Protein_position": AnnotationEntry("Protein", PosLength.from_vep_str),
+    "CLIN_SIG": AnnotationEntry(
+        "CLIN_SIG", lambda x: [v.strip() for v in x.split("&")], lambda: []
+    ),
 }
 
 KNOWN_ANN_TYPE_MAP = {**KNOWN_ANN_TYPE_MAP_SNPEFF, **KNOWN_ANN_TYPE_MAP_VEP}
+
+ANN_TYPER = AnnotationTyper(KNOWN_ANN_TYPE_MAP)

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -66,7 +66,7 @@ class PosLength:
             #  or start position only
             else [int(value.strip())] * 2
         )
-        return cls(start, start + end)
+        return cls(start, end - start)
 
     def __str__(self):
         return f"(pos: {self.pos}, length: {self.length})"

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -112,7 +112,6 @@ class AnnotationTyper:
         self._mapping = mapping
 
     def convert(self, key: str, value: str) -> Tuple[str, AnnotationType]:
-
         return self._mapping.get(key, DefaultAnnotationEntry(key)).convert(value)
 
 


### PR DESCRIPTION
Instead of trying to auto convert, default to unmodified values, i.e. the user has to do type conversion in the query -- if there is no pre-defined conversion in the `AnnotationTyper`. When no conversion entry is found for a given key, issue an INFO with a link to this project's issue tracker