### PR TITLE
Add release drafter GitHub workflow

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,0 +1,12 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - main
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
... so a draft release is always open until somebody puts in the correct version tag and hits "Publish release"