### PR TITLE
Replace usages of "ANN" with annotation-key specified on the CLI

### DIFF
--- a/tests/testcases/test10/config.yaml
+++ b/tests/testcases/test10/config.yaml
@@ -1,0 +1,2 @@
+ann_key: CSQ
+filter_expression: 'CSQ["Gene_Name"] == "CDH2" and CSQ["Annotation_Impact"] == "HIGH"'

--- a/tests/testcases/test10/expected.vcf
+++ b/tests/testcases/test10/expected.vcf
@@ -1,0 +1,89 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##content=strelka somatic snv calls
+##priorSomaticSnvRate=0.0001
+##INFO=<ID=QSS,Number=1,Type=Integer,Description="Quality score for any somatic snv, ie. for the ALT allele to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSS,Number=1,Type=Integer,Description="Data tier used to compute QSS">
+##INFO=<ID=NT,Number=1,Type=String,Description="Genotype of the normal in all data tiers, as used to classify somatic variants. One of {ref,het,hom,conflict}.">
+##INFO=<ID=QSS_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSS_NT,Number=1,Type=Integer,Description="Data tier used to compute QSS_NT">
+##INFO=<ID=SGT,Number=1,Type=String,Description="Most likely somatic genotype excluding normal noise states">
+##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Somatic mutation">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Combined depth across samples">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref read-position in the tumor">
+##INFO=<ID=SNVSB,Number=1,Type=Float,Description="Somatic SNV site strand bias">
+##INFO=<ID=PNOISE,Number=1,Type=Float,Description="Fraction of panel containing non-reference noise at this site">
+##INFO=<ID=PNOISE2,Number=1,Type=Float,Description="Fraction of panel containing more than one non-reference noise obs at this site">
+##INFO=<ID=SomaticEVS,Number=1,Type=Float,Description="Somatic Empirical Variant Score (EVS) expressing the phred-scaled probability of the call being a false positive observation.">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth for tier1 (used+filtered)">
+##FORMAT=<ID=FDP,Number=1,Type=Integer,Description="Number of basecalls filtered from original read depth for tier1">
+##FORMAT=<ID=SDP,Number=1,Type=Integer,Description="Number of reads with deletions spanning this site at tier1">
+##FORMAT=<ID=SUBDP,Number=1,Type=Integer,Description="Number of reads below tier1 mapping quality threshold aligned across this site">
+##FORMAT=<ID=AU,Number=2,Type=Integer,Description="Number of 'A' alleles used in tiers 1,2">
+##FORMAT=<ID=CU,Number=2,Type=Integer,Description="Number of 'C' alleles used in tiers 1,2">
+##FORMAT=<ID=GU,Number=2,Type=Integer,Description="Number of 'G' alleles used in tiers 1,2">
+##FORMAT=<ID=TU,Number=2,Type=Integer,Description="Number of 'T' alleles used in tiers 1,2">
+##FILTER=<ID=LowEVS,Description="Somatic Empirical Variant Score (SomaticEVS) is below threshold">
+##FILTER=<ID=LowDepth,Description="Tumor or normal sample read depth at this locus is below 2">
+##priorSomaticIndelRate=1e-06
+##INFO=<ID=QSI,Number=1,Type=Integer,Description="Quality score for any somatic variant, ie. for the ALT haplotype to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSI,Number=1,Type=Integer,Description="Data tier used to compute QSI">
+##INFO=<ID=QSI_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSI_NT,Number=1,Type=Integer,Description="Data tier used to compute QSI_NT">
+##INFO=<ID=RU,Number=1,Type=String,Description="Smallest repeating sequence unit in inserted or deleted sequence">
+##INFO=<ID=RC,Number=1,Type=Integer,Description="Number of times RU repeats in the reference allele">
+##INFO=<ID=IC,Number=1,Type=Integer,Description="Number of times RU repeats in the indel allele">
+##INFO=<ID=IHP,Number=1,Type=Integer,Description="Largest reference interrupted homopolymer length intersecting with the indel">
+##INFO=<ID=OVERLAP,Number=0,Type=Flag,Description="Somatic indel possibly overlaps a second indel.">
+##FORMAT=<ID=DP2,Number=1,Type=Integer,Description="Read depth for tier2">
+##FORMAT=<ID=TAR,Number=2,Type=Integer,Description="Reads strongly supporting alternate allele for tiers 1,2">
+##FORMAT=<ID=TIR,Number=2,Type=Integer,Description="Reads strongly supporting indel allele for tiers 1,2">
+##FORMAT=<ID=TOR,Number=2,Type=Integer,Description="Other reads (weak support or insufficient indel breakpoint overlap) for tiers 1,2">
+##FORMAT=<ID=DP50,Number=1,Type=Float,Description="Average tier1 read depth within 50 bases">
+##FORMAT=<ID=FDP50,Number=1,Type=Float,Description="Average tier1 number of basecalls filtered from original read depth within 50 bases">
+##FORMAT=<ID=SUBDP50,Number=1,Type=Float,Description="Average number of reads below tier1 mapping quality threshold aligned across sites within 50 bases">
+##FORMAT=<ID=BCN50,Number=1,Type=Float,Description="Fraction of filtered reads within 50 bases of the indel.">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##bcftools_viewCommand=view -O b -s TUMOR -o strelka/somatic/UKEMel103a/results/variants/somatic.complete.tumor.bcf strelka/somatic/UKEMel103a/results/variants/somatic.complete.bcf; Date=Wed Dec 18 10:06:07 2019
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the region described in this record">
+##INFO=<ID=BLOCKAVG_min30p3a,Number=0,Type=Flag,Description="Non-variant multi-site block. Non-variant blocks are defined independently for each sample. All sites in such a block are constrained to be non-variant, have the same filter value, and have sample values {GQX,DP,DPF} in range [x,y], y <= max(x+3,(x*1.3)).">
+##INFO=<ID=SNVHPOL,Number=1,Type=Integer,Description="SNV contextual homopolymer length">
+##INFO=<ID=CIGAR,Number=A,Type=String,Description="CIGAR alignment for each alternate indel allele">
+##INFO=<ID=REFREP,Number=A,Type=Integer,Description="Number of times RU is repeated in reference">
+##INFO=<ID=IDREP,Number=A,Type=Integer,Description="Number of times RU is repeated in indel allele">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GQX,Number=1,Type=Integer,Description="Empirically calibrated genotype quality score for variant sites, otherwise minimum of {Genotype quality assuming variant position,Genotype quality assuming non-variant position}">
+##FORMAT=<ID=DPF,Number=1,Type=Integer,Description="Basecalls filtered from input prior to site genotyping. In a non-variant multi-site block this value represents the average of all sites in the block.">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum filtered basecall depth used for site genotyping within a non-variant multi-site block">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed. For indels this value only includes reads which confidently support each allele (posterior prob 0.51 or higher that read contains indicated allele vs all other intersecting indel alleles)">
+##FORMAT=<ID=ADF,Number=.,Type=Integer,Description="Allelic depths on the forward strand">
+##FORMAT=<ID=ADR,Number=.,Type=Integer,Description="Allelic depths on the reverse strand">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample filter, 'PASS' indicates that all filters have passed for this sample">
+##FORMAT=<ID=DPI,Number=1,Type=Integer,Description="Read depth associated with indel, taken from the site preceding the indel">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set identifier">
+##FORMAT=<ID=SB,Number=1,Type=Float,Description="Sample site strand bias">
+##FILTER=<ID=IndelConflict,Description="Indel genotypes from two or more loci conflict in at least one sample">
+##FILTER=<ID=SiteConflict,Description="Site is filtered due to an overlapping indel call filter">
+##FILTER=<ID=LowGQX,Description="Locus GQX is below threshold or not present">
+##FILTER=<ID=HighDPFRatio,Description="The fraction of basecalls filtered out at a site is greater than 0.4">
+##FILTER=<ID=HighSNVSB,Description="Sample SNV strand bias value (SB) exceeds 10">
+##FILTER=<ID=NotGenotyped,Description="Locus contains forcedGT input alleles which could not be genotyped">
+##FILTER=<ID=PloidyConflict,Description="Genotype call from variant caller not consistent with chromosome ploidy">
+##FILTER=<ID=NoPassedVariantGTs,Description="No samples at this locus pass all sample filters and have a variant genotype">
+##SnpEffVersion="4.3t (build 2017-11-24 10:18), by Pablo Cingolani"
+##SnpEffCmd="SnpEff  hg38 - "
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO'">
+##INFO=<ID=LOF,Number=.,Type=String,Description="Predicted loss of function effects for this variant. Format: 'Gene_Name | Gene_ID | Number_of_transcripts_in_gene | Percent_of_transcripts_affected'">
+##INFO=<ID=NMD,Number=.,Type=String,Description="Predicted nonsense mediated decay effects for this variant. Format: 'Gene_Name | Gene_ID | Number_of_transcripts_in_gene | Percent_of_transcripts_affected'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+chr18	28036487	.	A	T	162	PASS	SNVHPOL=2;MQ=60;CSQ=T|stop_gained|HIGH|CDH2|CDH2|transcript|NM_001308176.1|protein_coding|1/15|c.62T>A|p.Leu21*|99/3855|62/2628|21/875||;LOF=(CDH2|CDH2|2|0.50);NMD=(CDH2|CDH2|2|0.50)	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	0/1:195:162:36:4:19,17:13,11:6,6:-20:PASS:197,0,216

--- a/tests/testcases/test10/test.vcf
+++ b/tests/testcases/test10/test.vcf
@@ -1,0 +1,96 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##content=strelka somatic snv calls
+##priorSomaticSnvRate=0.0001
+##INFO=<ID=QSS,Number=1,Type=Integer,Description="Quality score for any somatic snv, ie. for the ALT allele to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSS,Number=1,Type=Integer,Description="Data tier used to compute QSS">
+##INFO=<ID=NT,Number=1,Type=String,Description="Genotype of the normal in all data tiers, as used to classify somatic variants. One of {ref,het,hom,conflict}.">
+##INFO=<ID=QSS_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSS_NT,Number=1,Type=Integer,Description="Data tier used to compute QSS_NT">
+##INFO=<ID=SGT,Number=1,Type=String,Description="Most likely somatic genotype excluding normal noise states">
+##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Somatic mutation">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Combined depth across samples">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref read-position in the tumor">
+##INFO=<ID=SNVSB,Number=1,Type=Float,Description="Somatic SNV site strand bias">
+##INFO=<ID=PNOISE,Number=1,Type=Float,Description="Fraction of panel containing non-reference noise at this site">
+##INFO=<ID=PNOISE2,Number=1,Type=Float,Description="Fraction of panel containing more than one non-reference noise obs at this site">
+##INFO=<ID=SomaticEVS,Number=1,Type=Float,Description="Somatic Empirical Variant Score (EVS) expressing the phred-scaled probability of the call being a false positive observation.">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth for tier1 (used+filtered)">
+##FORMAT=<ID=FDP,Number=1,Type=Integer,Description="Number of basecalls filtered from original read depth for tier1">
+##FORMAT=<ID=SDP,Number=1,Type=Integer,Description="Number of reads with deletions spanning this site at tier1">
+##FORMAT=<ID=SUBDP,Number=1,Type=Integer,Description="Number of reads below tier1 mapping quality threshold aligned across this site">
+##FORMAT=<ID=AU,Number=2,Type=Integer,Description="Number of 'A' alleles used in tiers 1,2">
+##FORMAT=<ID=CU,Number=2,Type=Integer,Description="Number of 'C' alleles used in tiers 1,2">
+##FORMAT=<ID=GU,Number=2,Type=Integer,Description="Number of 'G' alleles used in tiers 1,2">
+##FORMAT=<ID=TU,Number=2,Type=Integer,Description="Number of 'T' alleles used in tiers 1,2">
+##FILTER=<ID=LowEVS,Description="Somatic Empirical Variant Score (SomaticEVS) is below threshold">
+##FILTER=<ID=LowDepth,Description="Tumor or normal sample read depth at this locus is below 2">
+##priorSomaticIndelRate=1e-06
+##INFO=<ID=QSI,Number=1,Type=Integer,Description="Quality score for any somatic variant, ie. for the ALT haplotype to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSI,Number=1,Type=Integer,Description="Data tier used to compute QSI">
+##INFO=<ID=QSI_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSI_NT,Number=1,Type=Integer,Description="Data tier used to compute QSI_NT">
+##INFO=<ID=RU,Number=1,Type=String,Description="Smallest repeating sequence unit in inserted or deleted sequence">
+##INFO=<ID=RC,Number=1,Type=Integer,Description="Number of times RU repeats in the reference allele">
+##INFO=<ID=IC,Number=1,Type=Integer,Description="Number of times RU repeats in the indel allele">
+##INFO=<ID=IHP,Number=1,Type=Integer,Description="Largest reference interrupted homopolymer length intersecting with the indel">
+##INFO=<ID=OVERLAP,Number=0,Type=Flag,Description="Somatic indel possibly overlaps a second indel.">
+##FORMAT=<ID=DP2,Number=1,Type=Integer,Description="Read depth for tier2">
+##FORMAT=<ID=TAR,Number=2,Type=Integer,Description="Reads strongly supporting alternate allele for tiers 1,2">
+##FORMAT=<ID=TIR,Number=2,Type=Integer,Description="Reads strongly supporting indel allele for tiers 1,2">
+##FORMAT=<ID=TOR,Number=2,Type=Integer,Description="Other reads (weak support or insufficient indel breakpoint overlap) for tiers 1,2">
+##FORMAT=<ID=DP50,Number=1,Type=Float,Description="Average tier1 read depth within 50 bases">
+##FORMAT=<ID=FDP50,Number=1,Type=Float,Description="Average tier1 number of basecalls filtered from original read depth within 50 bases">
+##FORMAT=<ID=SUBDP50,Number=1,Type=Float,Description="Average number of reads below tier1 mapping quality threshold aligned across sites within 50 bases">
+##FORMAT=<ID=BCN50,Number=1,Type=Float,Description="Fraction of filtered reads within 50 bases of the indel.">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##bcftools_viewCommand=view -O b -s TUMOR -o strelka/somatic/UKEMel103a/results/variants/somatic.complete.tumor.bcf strelka/somatic/UKEMel103a/results/variants/somatic.complete.bcf; Date=Wed Dec 18 10:06:07 2019
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the region described in this record">
+##INFO=<ID=BLOCKAVG_min30p3a,Number=0,Type=Flag,Description="Non-variant multi-site block. Non-variant blocks are defined independently for each sample. All sites in such a block are constrained to be non-variant, have the same filter value, and have sample values {GQX,DP,DPF} in range [x,y], y <= max(x+3,(x*1.3)).">
+##INFO=<ID=SNVHPOL,Number=1,Type=Integer,Description="SNV contextual homopolymer length">
+##INFO=<ID=CIGAR,Number=A,Type=String,Description="CIGAR alignment for each alternate indel allele">
+##INFO=<ID=REFREP,Number=A,Type=Integer,Description="Number of times RU is repeated in reference">
+##INFO=<ID=IDREP,Number=A,Type=Integer,Description="Number of times RU is repeated in indel allele">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GQX,Number=1,Type=Integer,Description="Empirically calibrated genotype quality score for variant sites, otherwise minimum of {Genotype quality assuming variant position,Genotype quality assuming non-variant position}">
+##FORMAT=<ID=DPF,Number=1,Type=Integer,Description="Basecalls filtered from input prior to site genotyping. In a non-variant multi-site block this value represents the average of all sites in the block.">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum filtered basecall depth used for site genotyping within a non-variant multi-site block">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed. For indels this value only includes reads which confidently support each allele (posterior prob 0.51 or higher that read contains indicated allele vs all other intersecting indel alleles)">
+##FORMAT=<ID=ADF,Number=.,Type=Integer,Description="Allelic depths on the forward strand">
+##FORMAT=<ID=ADR,Number=.,Type=Integer,Description="Allelic depths on the reverse strand">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample filter, 'PASS' indicates that all filters have passed for this sample">
+##FORMAT=<ID=DPI,Number=1,Type=Integer,Description="Read depth associated with indel, taken from the site preceding the indel">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set identifier">
+##FORMAT=<ID=SB,Number=1,Type=Float,Description="Sample site strand bias">
+##FILTER=<ID=IndelConflict,Description="Indel genotypes from two or more loci conflict in at least one sample">
+##FILTER=<ID=SiteConflict,Description="Site is filtered due to an overlapping indel call filter">
+##FILTER=<ID=LowGQX,Description="Locus GQX is below threshold or not present">
+##FILTER=<ID=HighDPFRatio,Description="The fraction of basecalls filtered out at a site is greater than 0.4">
+##FILTER=<ID=HighSNVSB,Description="Sample SNV strand bias value (SB) exceeds 10">
+##FILTER=<ID=NotGenotyped,Description="Locus contains forcedGT input alleles which could not be genotyped">
+##FILTER=<ID=PloidyConflict,Description="Genotype call from variant caller not consistent with chromosome ploidy">
+##FILTER=<ID=NoPassedVariantGTs,Description="No samples at this locus pass all sample filters and have a variant genotype">
+##SnpEffVersion="4.3t (build 2017-11-24 10:18), by Pablo Cingolani"
+##SnpEffCmd="SnpEff  hg38 - "
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO'">
+##INFO=<ID=LOF,Number=.,Type=String,Description="Predicted loss of function effects for this variant. Format: 'Gene_Name | Gene_ID | Number_of_transcripts_in_gene | Percent_of_transcripts_affected'">
+##INFO=<ID=NMD,Number=.,Type=String,Description="Predicted nonsense mediated decay effects for this variant. Format: 'Gene_Name | Gene_ID | Number_of_transcripts_in_gene | Percent_of_transcripts_affected'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+chr18	27963423	.	G	A	276	PASS	SNVHPOL=2;MQ=60;CSQ=A|synonymous_variant|LOW|CDH2|CDH2|transcript|NM_001792.4|protein_coding|15/16|c.2448C>T|p.Ala816Ala|2872/4335|2448/2721|816/906||,A|synonymous_variant|LOW|CDH2|CDH2|transcript|NM_001308176.1|protein_coding|14/15|c.2355C>T|p.Ala785Ala|2392/3855|2355/2628|785/875||	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	0/1:250:250:61:1:28,33:15,21:13,12:-27.4:PASS:310,0,247
+chr18	27963698	.	T	C	30	PASS	SNVHPOL=3;MQ=60;CSQ=C|intron_variant|MODIFIER|CDH2|CDH2|transcript|NM_001792.4|protein_coding|14/15|c.2350-177A>G||||||,C|intron_variant|MODIFIER|CDH2|CDH2|transcript|NM_001308176.1|protein_coding|13/14|c.2257-177A>G||||||	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	0/1:63:30:7:0:4,3:0,0:4,3:0:PASS:65,0,78
+chr18	28036487	.	A	T	162	PASS	SNVHPOL=2;MQ=60;CSQ=T|stop_gained|HIGH|CDH2|CDH2|transcript|NM_001308176.1|protein_coding|1/15|c.62T>A|p.Leu21*|99/3855|62/2628|21/875||,T|intron_variant|MODIFIER|CDH2|CDH2|transcript|NM_001792.4|protein_coding|2/15|c.173-22578T>A||||||;LOF=(CDH2|CDH2|2|0.50);NMD=(CDH2|CDH2|2|0.50)	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	0/1:195:162:36:4:19,17:13,11:6,6:-20:PASS:197,0,216
+chr18	28045161	.	G	A	37	PASS	SNVHPOL=2;MQ=60;CSQ=A|intron_variant|MODIFIER|CDH2|CDH2|transcript|NM_001792.4|protein_coding|2/15|c.173-31252C>T||||||	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	0/1:59:37:4:0:2,2:2,1:0,1:-7.5:PASS:72,0,56
+chr18	36126053	.	T	C	40	PASS	SNVHPOL=3;MQ=60;CSQ=C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242875.2|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242876.2|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242877.2|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242878.2|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242879.2|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324465.1|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324466.1|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324467.1|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324468.1|protein_coding||c.-12744T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_018255.3|protein_coding||c.-3881T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_040110.2|pseudogene||n.-3821T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_136897.1|pseudogene||n.-3821T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_136898.1|pseudogene||n.-3821T>C|||||3821|,C|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_137173.1|pseudogene||n.-3821T>C|||||3821|,C|intron_variant|MODIFIER|SLC39A6|SLC39A6|transcript|NM_012319.3|protein_coding|2/9|c.789+166A>G||||||,C|intron_variant|MODIFIER|SLC39A6|SLC39A6|transcript|NM_001099406.1|protein_coding|1/7|c.-36-1353A>G||||||	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	0/1:33:32:4:0:1,3:1,3:0,0:0:PASS:74,0,30
+chr18	36126651	.	C	G	1771	PASS	SNVHPOL=2;MQ=60;CSQ=G|missense_variant|MODERATE|SLC39A6|SLC39A6|transcript|NM_012319.3|protein_coding|2/10|c.357G>C|p.Glu119Asp|647/3620|357/2268|119/755||,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242875.2|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242876.2|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242877.2|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242878.2|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001242879.2|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324465.1|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324466.1|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324467.1|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_001324468.1|protein_coding||c.-12146C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NM_018255.3|protein_coding||c.-3283C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_040110.2|pseudogene||n.-3223C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_136897.1|pseudogene||n.-3223C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_136898.1|pseudogene||n.-3223C>G|||||3223|,G|upstream_gene_variant|MODIFIER|ELP2|ELP2|transcript|NR_137173.1|pseudogene||n.-3223C>G|||||3223|,G|intron_variant|MODIFIER|SLC39A6|SLC39A6|transcript|NM_001099406.1|protein_coding|1/7|c.-36-1951G>C||||||	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	1/1:430:430:144:5:0,144:0,74:0,70:-99:PASS:370,370,0
+chr18	46546946	.	T	C	2045	PASS	SNVHPOL=5;MQ=60;CSQ=C|missense_variant|MODERATE|LOXHD1|LOXHD1|transcript|NM_144612.6|protein_coding|22/40|c.3463A>G|p.Arg1155Gly|3463/6854|3463/6636|1155/2211||,C|missense_variant|MODERATE|LOXHD1|LOXHD1|transcript|NM_001145472.2|protein_coding|4/24|c.130A>G|p.Arg44Gly|539/3965|130/3345|44/1114||,C|5_prime_UTR_variant|MODIFIER|LOXHD1|LOXHD1|transcript|NM_001308013.1|protein_coding|2/22|c.-159A>G|||||4093|	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	1/1:500:500:167:7:0,167:0,85:0,82:-99:PASS:370,370,0
+chr18	47034729	.	C	G	272	PASS	SNVHPOL=3;MQ=60;CSQ=G|missense_variant|MODERATE|TCEB3B|TCEB3B|transcript|NM_016427.2|protein_coding|1/1|c.536G>C|p.Arg179Pro|889/3046|536/2262|179/753||,G|upstream_gene_variant|MODIFIER|TCEB3CL|TCEB3CL.3|transcript|NM_001100817.1.3|protein_coding||c.-4887G>C|||||4887|,G|upstream_gene_variant|MODIFIER|TCEB3C|TCEB3C.2|transcript|NM_145653.3.2|protein_coding||c.-4887G>C|||||4651|,G|intron_variant|MODIFIER|KATNAL2|KATNAL2|transcript|NM_031303.2|protein_coding|1/14|c.-94-18151C>G||||||	GT:GQ:GQX:DP:DPF:AD:ADF:ADR:SB:FT:PL	0/1:305:272:88:2:48,40:26,22:22,18:-33.4:PASS:307,0,370


### PR DESCRIPTION
When using the `--annotation-key FOO` option, expressions now actually use `FOO` as the dict name, e.g. `FOO["Gene_Name"] == "CDH2"` instead of `ANN["Gene_Name"] == "CDH2"`.