### PR TITLE
Check for annotation_key in the filter expression via walking the ast

### DIFF
--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -119,7 +119,10 @@ class Expression:
     def __init__(self, expression: str, ann_key: str = "ANN"):
         self._expression = expression
         self._ann_key = ann_key
-        self._has_ann = f"{ann_key}[" in expression
+        self._has_ann = any(
+            hasattr(node, "id") and node.id == ann_key
+            for node in ast.walk(ast.parse(expression))
+        )
 
     def annotation_key(self):
         return self._ann_key

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -120,7 +120,7 @@ class Expression:
         self._expression = expression
         self._ann_key = ann_key
         self._has_ann = any(
-            hasattr(node, "id") and node.id == ann_key
+            hasattr(node, "id") and isinstance(node, ast.Name) and node.id == ann_key
             for node in ast.walk(ast.parse(expression))
         )
 


### PR DESCRIPTION
Instead of checking if the expression string contains the annotation_key string, walk the expression's ast and check if that contains a node with `id == ann_key`