### PR TITLE
Swap expression and VCF input positional arguments, make input default to stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,31 +38,31 @@ The following VCF fields can be accessed in the filter expression:
 
 * Only keep annotations and variants where gene equals "CDH2" and its impact is "HIGH":
   ```
-  vembrane variants.bcf 'ANN["Gene_Name"] == "CDH2" and ANN["Annotation_Impact"] == "HIGH"'
+  vembrane 'ANN["Gene_Name"] == "CDH2" and ANN["Annotation_Impact"] == "HIGH"' variants.bcf
   ```
 * Only keep variants with quality at least 30:
   ```
-  vembrane variants.vcf 'QUAL >= 30'
+  vembrane 'QUAL >= 30' variants.vcf
   ```
 * Only keep annotations and variants where feature (transcript) is ENST00000307301:
   ```
-  vembrane variants.bcf 'ANN["Feature"] == "ENST00000307301"'
+  vembrane 'ANN["Feature"] == "ENST00000307301"' variants.bcf
   ```
 * Only keep annotations and variants where protein position is less than 10:
   ```
-  vembrane variants.bcf 'ANN["Protein"].start < 10'
+  vembrane 'ANN["Protein"].start < 10' variants.bcf
   ```
 * Only keep variants where mapping quality is exactly 60:
   ```
-  vembrane variants.bcf 'INFO["MQ"] == 60'
+  vembrane 'INFO["MQ"] == 60' variants.bcf
   ```
 * Only keep annotations and variants where consequence contains the word "stream" (matching "upstream" and "downstream"):
   ```
-  vembrane variants.vcf 're.search("stream", ANN["Consequence"])'
+  vembrane 're.search("stream", ANN["Consequence"])' variants.vcf
   ```
 * Only keep annotations and variants where CLIN_SIG contains "pathogenic", "likely_pathogenic" or "drug_response":
   ```
-  vembrane variants.vcf 'any(entry in ANN["CLIN_SIG"] for entry in ("pathogenic", "likely_pathogenic", "drug_response"))'
+  vembrane 'any(entry in ANN["CLIN_SIG"] for entry in ("pathogenic", "likely_pathogenic", "drug_response"))' variants.vcf
   ```
 
 ## Custom ANN types

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -249,12 +249,14 @@ def check_filter_expression(expression: str,) -> str:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("vcf", help="The file containing the variants.")
     parser.add_argument(
         "expression",
         type=check_filter_expression,
         help="Filter variants and annotations. If this removes all annotations, "
         "the variant is removed as well.",
+    )
+    parser.add_argument(
+        "vcf", help="The file containing the variants.", nargs="?", default="-"
     )
     parser.add_argument(
         "--output",


### PR DESCRIPTION
In concordance with other VCF filtering tools, as well as to make it easier to use vembrane in a pipe chain, such as `bcftools view foo.vcf | vembrane "some expression" | whatever`, swap the order of positional arguments `expression` and `vcf`.