### PR TITLE
Parse info/annotation entries only on dict lookup

### DIFF
--- a/tests/test_vembrane.py
+++ b/tests/test_vembrane.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 from pysam import VariantFile
 
-from vembrane import errors, Expression, __version__, filter_vcf
+from vembrane import errors, __version__, filter_vcf
 
 CASES = Path(__file__).parent.joinpath("testcases")
 
@@ -37,9 +37,8 @@ def test_filter(testcase):
             list(
                 filter_vcf(
                     vcf,
-                    Expression(
-                        config.get("filter_expression"), config.get("ann_key", "ANN")
-                    ),
+                    config.get("filter_expression"),
+                    config.get("ann_key", "ANN"),
                     config.get("keep_unmatched", False),
                 )
             )
@@ -48,9 +47,8 @@ def test_filter(testcase):
         result = list(
             filter_vcf(
                 vcf,
-                Expression(
-                    config.get("filter_expression"), config.get("ann_key", "ANN")
-                ),
+                config.get("filter_expression"),
+                config.get("ann_key", "ANN"),
                 config.get("keep_unmatched", False),
             )
         )

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -13,7 +13,6 @@ import math
 import re
 import sys
 from collections import defaultdict
-from functools import lru_cache
 from itertools import chain
 from sys import stderr
 from typing import Iterator, List, Tuple
@@ -122,7 +121,7 @@ class Annotation:
     def update(self, record_idx: int, annotation: str):
         self._record_idx = record_idx
         self._data.clear()
-        self._annotation_data = parse_annotation_entry(annotation)
+        self._annotation_data = split_annotation_entry(annotation)
 
     def __getitem__(self, item):
         try:
@@ -150,8 +149,7 @@ def get_annotation_keys(header: VariantHeader, ann_key: str) -> List[str]:
     return []
 
 
-@lru_cache(maxsize=32)
-def parse_annotation_entry(entry: str,) -> List[str]:
+def split_annotation_entry(entry: str,) -> List[str]:
     return entry.split("|")
 
 
@@ -305,7 +303,7 @@ def statistics(
     for record in records:
         for annotation in record.info[ann_key]:
             for key, raw_value in zip(
-                annotation_keys, parse_annotation_entry(annotation)
+                annotation_keys, split_annotation_entry(annotation)
             ):
                 value = raw_value.strip()
                 if value:

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -160,6 +160,7 @@ def filter_vcf(
     annotation_keys = get_annotation_keys(header, ann_key)
 
     for idx, record in enumerate(vcf):
+        yield record
         continue
         # setup filter expression env
         env.clear()

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -272,7 +272,10 @@ def filter_vcf(
             # if the expression contains a reference to the ANN field
             # get all annotations from the record.info field
             # (or supply an empty ANN value if the record has no ANN field)
-            annotations = record.info.get(ann_key, [""])
+            try:
+                annotations = record.info[ann_key]
+            except KeyError:
+                annotations = [""]
             #  … and only keep the annotations where the expression evaluates to true
             filtered_annotations = [
                 annotation for annotation in annotations if env.evaluate(annotation)

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -160,8 +160,6 @@ def filter_vcf(
     annotation_keys = get_annotation_keys(header, ann_key)
 
     for idx, record in enumerate(vcf):
-        yield record
-        continue
         # setup filter expression env
         env.clear()
         for name in header.info:
@@ -192,7 +190,7 @@ def filter_vcf(
             # if the expression contains a reference to the ANN field
             # get all annotations from the record.info field
             # (or supply an empty ANN value if the record has no ANN field)
-            annotations = dict(record.info).get(ann_key, [""])
+            annotations = record.info.get(ann_key, [""])
             #  … and only keep the annotations where the expression evaluates to true
             filtered_annotations = [
                 annotation

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -16,10 +16,11 @@ from collections import defaultdict
 from functools import lru_cache
 from itertools import chain
 from sys import stderr
-from typing import Iterator, List
+from typing import Iterator, List, Tuple
 
 import yaml
 from pysam import VariantFile, VariantRecord, VariantHeader
+from pysam.libcbcf import VariantRecordInfo, VariantRecordSample
 
 from vembrane.ann_types import NA, type_info, ANN_TYPER
 from vembrane.errors import (
@@ -49,7 +50,7 @@ globals_whitelist = {
 
 
 class Sample:
-    def __init__(self, record_idx: int, sample_name: str, sample):
+    def __init__(self, record_idx: int, sample_name: str, sample: VariantRecordSample):
         self._record_idx = record_idx
         self._sample_name = sample_name
         self._sample = sample
@@ -68,7 +69,7 @@ class Sample:
 
 
 class Format:
-    def __init__(self, record_idx: int, record_samples):
+    def __init__(self, record_idx: int, record_samples: List[VariantRecordSample]):
         self._record_idx = record_idx
         self._record_samples = record_samples
         self._sample_formats = {}
@@ -87,7 +88,7 @@ class Format:
 
 
 class Info:
-    def __init__(self, record_idx: int, record_info, ann_key: str):
+    def __init__(self, record_idx: int, record_info: VariantRecordInfo, ann_key: str):
         self._record_idx = record_idx
         self._record_info = record_info
         self._ann_key = ann_key
@@ -210,7 +211,7 @@ class Environment(dict):
         self._globals["ID"] = value
         return value
 
-    def _get_ref_alt(self):
+    def _get_ref_alt(self) -> Tuple[str, List[str]]:
         ref, *alt = chain(self.record.alleles)
         self._globals["REF"], self._globals["ALT"] = ref, alt
         return ref, alt
@@ -218,10 +219,10 @@ class Environment(dict):
     def _get_ref(self) -> str:
         return self._get_ref_alt()[0]
 
-    def _get_alt(self):
+    def _get_alt(self) -> List[str]:
         return self._get_ref_alt()[1]
 
-    def _get_qual(self):
+    def _get_qual(self) -> float:
         value = type_info(self.record.qual)
         self._globals["QUAL"] = value
         return value
@@ -241,7 +242,7 @@ class Environment(dict):
         self._globals["FORMAT"] = value
         return value
 
-    def _get_samples(self):
+    def _get_samples(self) -> List[VariantRecordSample]:
         value = list(self.record.samples)
         self._globals["SAMPLES"] = value
         return value

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -190,22 +190,22 @@ class Environment(dict):
     def filters_annotations(self):
         return self._has_ann
 
-    def update(self, idx, record):
+    def update(self, idx: int, record: VariantRecord):
         self.idx = idx
         self.record = record
         self._globals.update(self._empty_globals)
 
-    def _get_chrom(self):
+    def _get_chrom(self) -> str:
         value = self.record.chrom
         self._globals["CHROM"] = value
         return value
 
-    def _get_pos(self):
+    def _get_pos(self) -> int:
         value = self.record.pos
         self._globals["POS"] = value
         return value
 
-    def _get_id(self):
+    def _get_id(self) -> str:
         value = self.record.id
         self._globals["ID"] = value
         return value
@@ -215,7 +215,7 @@ class Environment(dict):
         self._globals["REF"], self._globals["ALT"] = ref, alt
         return ref, alt
 
-    def _get_ref(self):
+    def _get_ref(self) -> str:
         return self._get_ref_alt()[0]
 
     def _get_alt(self):
@@ -226,17 +226,17 @@ class Environment(dict):
         self._globals["QUAL"] = value
         return value
 
-    def _get_filter(self):
+    def _get_filter(self) -> str:
         value = self.record.filter
         self._globals["FILTER"] = value
         return value
 
-    def _get_info(self):
+    def _get_info(self) -> Info:
         value = Info(self.idx, self.record.info, self._ann_key)
         self._globals["INFO"] = value
         return value
 
-    def _get_format(self):
+    def _get_format(self) -> Format:
         value = Format(self.idx, self.record.samples)
         self._globals["FORMAT"] = value
         return value

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -255,7 +255,7 @@ class Environment(dict):
             value = self._getters[item]()
         return value
 
-    def evaluate(self, annotation: str,) -> bool:
+    def evaluate(self, annotation: str = "") -> bool:
         if self._has_ann:
             self._annotation.update(self.idx, annotation)
         return self._func()
@@ -291,7 +291,7 @@ def filter_vcf(
         else:
             # otherwise, the annotations are irrelevant w.r.t. the expression,
             # so we can omit them
-            if env.evaluate(""):
+            if env.evaluate():
                 yield record
             else:
                 continue

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -189,7 +189,7 @@ class Environment(dict):
     def filters_annotations(self):
         return self._has_ann
 
-    def update(self, idx: int, record: VariantRecord):
+    def update_from_record(self, idx: int, record: VariantRecord):
         self.idx = idx
         self.record = record
         self._globals.update(self._empty_globals)
@@ -266,7 +266,7 @@ def filter_vcf(
     env = Environment(expression, ann_key, vcf.header)
 
     for idx, record in enumerate(vcf):
-        env.update(idx, record)
+        env.update_from_record(idx, record)
         if env.filters_annotations():
             # if the expression contains a reference to the ANN field
             # get all annotations from the record.info field

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from functools import lru_cache
 from itertools import chain
 from sys import stderr
-from typing import Any, Dict, Iterator, List
+from typing import Iterator, List
 
 import yaml
 from pysam import VariantFile, VariantRecord, VariantHeader
@@ -49,28 +49,41 @@ globals_whitelist = {
 
 
 class Sample:
-    def __init__(self, record_idx: int, sample: str, format_data: Dict[str, Any]):
+    def __init__(self, record_idx: int, sample_name: str, sample):
         self._record_idx = record_idx
+        self._sample_name = sample_name
         self._sample = sample
-        self._data = format_data
+        self._data = {}
 
     def __getitem__(self, item):
         try:
             return self._data[item]
-        except KeyError as ke:
-            raise UnknownFormatField(self._record_idx, self._sample, ke)
+        except KeyError:
+            try:
+                sample_format = self._sample[item]
+            except KeyError as ke:
+                raise UnknownFormatField(self._record_idx, self._sample_name, ke)
+            self._data[item] = sample_format
+            return sample_format
 
 
 class Format:
-    def __init__(self, record_idx: int, sample_formats: Dict[Sample, Dict[str, Any]]):
+    def __init__(self, record_idx: int, record_samples):
         self._record_idx = record_idx
-        self._sample_formats = sample_formats
+        self._record_samples = record_samples
+        self._sample_formats = {}
 
     def __getitem__(self, item):
         try:
             return self._sample_formats[item]
-        except KeyError as ke:
-            raise UnknownSample(self._record_idx, ke)
+        except KeyError:
+            try:
+                record_sample = self._record_samples[item]
+            except KeyError as ke:
+                raise UnknownSample(self._record_idx, ke)
+            sample = Sample(self._record_idx, item, record_sample)
+            self._sample_formats[item] = sample
+            return sample
 
 
 class Info:
@@ -224,15 +237,7 @@ class Environment(dict):
         return value
 
     def _get_format(self):
-        idx = self.idx
-        record = self.record
-        formats = {
-            sample: Sample(
-                idx, sample, {fmt: record.samples[sample][fmt] for fmt in record.format}
-            )
-            for sample in record.samples
-        }
-        value = Format(idx, formats)
+        value = Format(self.idx, self.record.samples)
         self._globals["FORMAT"] = value
         return value
 

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -160,6 +160,7 @@ def filter_vcf(
     annotation_keys = get_annotation_keys(header, ann_key)
 
     for idx, record in enumerate(vcf):
+        continue
         # setup filter expression env
         env.clear()
         for name in header.info:

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -117,7 +117,10 @@ def parse_annotation_entry(entry: str,) -> List[str]:
 
 class Expression:
     def __init__(self, expression: str, ann_key: str = "ANN"):
-        self._expression = expression
+        # We use self._globals + self.func as a closure.
+        # Do not reassign self._globals, but use .update() on it!
+        self._globals = globals_whitelist.copy()
+        self._func = eval(f"lambda: {expression}", self._globals, {})
         self._ann_key = ann_key
         self._has_ann = any(
             hasattr(node, "id") and isinstance(node, ast.Name) and node.id == ann_key
@@ -142,7 +145,8 @@ class Expression:
                 )
             ),
         )
-        return eval(self._expression, globals_whitelist, env)
+        self._globals.update(env)
+        return self._func()
 
 
 def filter_vcf(

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -103,11 +103,15 @@ class AnnotationEntry:
         self._nafunc = nafunc
         self._description = description
 
+    @property
+    def name(self):
+        return self._name
+
     def convert(self, value: str) -> Tuple[str, Any]:
         if value:
-            return self._name, self._typefunc(value)
+            return self._typefunc(value)
         else:
-            return self._name, self._nafunc()
+            return self._nafunc()
 
     def description(self):
         return self._description
@@ -130,7 +134,7 @@ class AnnotationTyper:
     def __init__(self, mapping: Dict[str, AnnotationEntry]):
         self._mapping = mapping
 
-    def convert(self, key: str, value: str) -> Tuple[str, AnnotationType]:
+    def get_entry(self, key: str) -> Tuple[str, AnnotationType]:
         entry = self._mapping.get(key)
         if not entry:
             print(
@@ -142,7 +146,11 @@ class AnnotationTyper:
             )
             self._mapping[key] = DefaultAnnotationEntry(key)
             entry = self._mapping[key]
-        return entry.convert(value)
+        return entry
+
+    def convert(self, key: str, value: str) -> Tuple[str, AnnotationType]:
+        entry = self.get_entry(key)
+        return entry.name, entry.convert(value)
 
 
 KNOWN_ANN_TYPE_MAP_SNPEFF = {


### PR DESCRIPTION
This is an alternative to gh-61.
Whereas gh-61 does preprocessing via `ast.walk`, this PR does less preprocessing and decides on what values to parse on dicitonary lookups from the expression.
gh-61 should be faster but might prevent some "more exotic" uses/expression. This PR is more flexible but likely slower (and adds less logic).

This is likely functional but needs some cleanup still.