### PR TITLE
Only allow one ALT allele per record, error if more than one is encountered

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following VCF fields can be accessed in the filter expression:
 |`POS`| `int` | Chromosomal position  | `24 < POS < 42`|
 |`ID`| `str`  | Variant ID |  `ID == "rs11725853"` |
 |`REF`| `str` |  Reference allele  | `REF == "A"` |
-|`ALT`| `List[str]` |  Alternative alleles  | `"C" in ALT or ALT[0] == "G"`|
+|`ALT`| `str` |  Alternative allele³  | `ALT == "C"`|
 |`QUAL`| `float`  | Quality |  `QUAL >= 60` |
 |`FILTER`|  |   |  |
 |`FORMAT`|`Dict[str, Dict[str, Any¹]]`| `Format -> (Sample -> Value)` | `FORMAT["DP"][SAMPLES[0]] > 0` |
@@ -34,6 +34,12 @@ The following VCF fields can be accessed in the filter expression:
  ¹ depends on type specified in VCF header
 
  ² for the usual snpeff and vep annotations, custom types have been specified; any unknown ANN field will simply be of type `str`. If something lacks a custom parser/type, please consider filing an issue in the [issue tracker](https://github.com/vembrane/vembrane/issues).
+
+ ³ vembrane does not handle multi-allelic records itself. Instead, such files should be
+ preprocessed by either of the following tools (preferably even before annotation):
+ - [`bcftools norm -m-any […]`](http://samtools.github.io/bcftools/bcftools.html#norm)
+ - [`gatk LeftAlignAndTrimVariants […] --split-multi-allelics`](https://gatk.broadinstitute.org/hc/en-us/articles/360037225872-LeftAlignAndTrimVariants)
+ - [`vcfmulti2oneallele […]`](http://lindenb.github.io/jvarkit/VcfMultiToOneAllele.html)
 
 
 ## Examples

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -210,6 +210,13 @@ class Environment(dict):
             "SAMPLES": self._get_samples,
         }
 
+        # vembrane only supports bi-allelic records (i.e. one REF, one ALT allele).
+        # Hence, for all fields in the header whith `number in {"A", "R"}`
+        # we check if there is indeed only 1 value ("A") or 2 values ("R")
+        # and abort otherwise.
+        # Then, in the case of `number == "A"`, the value tuples only have one entry,
+        # so that the value can be accessed directly and need not be accessed via
+        # an index operation.
         self._numbers = {
             kind: {
                 record.get("ID"): record.get("Number")
@@ -218,6 +225,7 @@ class Environment(dict):
             }
             for kind in set(r.type for r in header.records)
         }
+        # At the moment, only INFO and FORMAT records are checked
         self._header_info_fields = self._numbers["INFO"]
         self._header_format_fields = self._numbers["FORMAT"]
         self._empty_globals = {name: UNSET for name in self._getters}

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -1,6 +1,8 @@
 from sys import stderr
 from typing import Union, Iterable, Tuple, Dict, Callable, Any
 
+from vembrane.errors import MoreThanOneAltAllele
+
 
 class NoValue:
     def __lt__(self, other):
@@ -43,11 +45,16 @@ class InfoTuple:
 IntFloatStr = Union[int, float, str]
 
 
-def type_info(value):
+def type_info(value, number="."):
     if value is None:
         return NA
     if isinstance(value, tuple):
-        return InfoTuple(value)
+        if number != "A":
+            return InfoTuple(value)
+        else:
+            if len(value) != 1:
+                raise MoreThanOneAltAllele()
+            return value[0]
     return value
 
 

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -54,7 +54,8 @@ def type_info(value, number="."):
         else:
             if len(value) != 1:
                 raise MoreThanOneAltAllele()
-            return value[0]
+            value = value[0]
+            return value if value is not None else NA
     return value
 
 

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -49,13 +49,18 @@ def type_info(value, number="."):
     if value is None:
         return NA
     if isinstance(value, tuple):
-        if number != "A":
+        if number not in {"A", "R"}:
             return InfoTuple(value)
         else:
-            if len(value) != 1:
-                raise MoreThanOneAltAllele()
-            value = value[0]
-            return value if value is not None else NA
+            if number == "A":
+                if len(value) != 1:
+                    raise MoreThanOneAltAllele()
+                value = value[0]
+                return value if value is not None else NA
+            if number == "R":
+                if len(value) != 2:
+                    raise MoreThanOneAltAllele()
+                return InfoTuple(value)
     return value
 
 

--- a/vembrane/errors.py
+++ b/vembrane/errors.py
@@ -56,3 +56,14 @@ class InvalidExpression(VembraneError):
             msg = f"The provided expression '{expression}' is invalid. Reason: {reason}"
         super(InvalidExpression, self).__init__(msg)
         self.expression = expression
+
+
+class MoreThanOneAltAllele(VembraneError):
+    """vembrane only supports one ALT allele per record"""
+
+    def __init__(self):
+        msg = (
+            "vembrane only supports records with one alternative allele.\n"
+            "Please run `bcftools norm -m-any` on the input file, first."
+        )
+        super(MoreThanOneAltAllele, self).__init__(msg)

--- a/vembrane/errors.py
+++ b/vembrane/errors.py
@@ -64,6 +64,9 @@ class MoreThanOneAltAllele(VembraneError):
     def __init__(self):
         msg = (
             "vembrane only supports records with one alternative allele.\n"
-            "Please run `bcftools norm -m-any` on the input file, first."
+            "Please split multi-allelic records first, for example with "
+            "`bcftools norm -m-any […]` or "
+            "`gatk LeftAlignAndTrimVariants […] --split-multi-allelics` or "
+            "`vcfmulti2oneallele […]`"
         )
         super(MoreThanOneAltAllele, self).__init__(msg)


### PR DESCRIPTION
In order to make syntax for handling `INFO` fields with one value per allele less unwieldy and reduce confusion, this PR forces users to have input files which have only one ALT allele per record, which can for example be achieved by calling `bcftools norm -m-any foo.vcf`. We could call `bcftools norm` ourselves via pysam (if it weren't for https://github.com/pysam-developers/pysam/issues/506), but that doesn't handle snpeff/vep/… annotations in the ANN/CSQ fields. We could also split multi-allelic records ourselves, but we'd rather not introduce additional functionality/complexity when there are established tools made for exactly this purpose.

~~However, this does not handle `FORMAT` yet, so I'll leave this as a draft for now.~~