### PR TITLE
Custom functions

### DIFF
--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -6,6 +6,8 @@ import re
 #        *sorted(o for o in dir(__builtins__) if o.islower() and not o.startswith("_")),
 #        sep="\n",
 #    )'
+from typing import Dict, Any
+
 from .ann_types import NA
 
 _builtins = {
@@ -109,3 +111,60 @@ allowed_globals = {
     **_explicit_clear,
     "NA": NA,
 }
+
+
+def custom_functions(env) -> Dict[str, Any]:
+    return {
+        "count_hom": eval(
+            "lambda: "
+            "sum(all(x == FORMAT['GT'][s][0] for x in FORMAT['GT'][s][1:]) "
+            "for s in SAMPLES)",
+            env,
+            {},
+        ),
+        "count_het": eval(
+            "lambda: "
+            "sum(any(x != FORMAT['GT'][s][0] for x in FORMAT['GT'][s][1:]) "
+            "for s in SAMPLES)",
+            env,
+            {},
+        ),
+        "count_ref": eval(
+            "lambda: "
+            "sum(all(x == 0 for x in FORMAT['GT'][s][1:]) "
+            "for s in SAMPLES)",
+            env,
+            {},
+        ),
+        "count_var": eval(
+            "lambda: "
+            "sum(any(x != 0 for x in FORMAT['GT'][s][1:]) "
+            "for s in SAMPLES)",
+            env,
+            {},
+        ),
+        "is_hom": eval(
+            f"lambda sample: "
+            f"all(x == FORMAT['GT'][sample][0] "
+            f"for x in FORMAT['GT'][sample][1:])",
+            env,
+            {},
+        ),
+        "is_het": eval(
+            f"lambda sample: "
+            f"any(x != FORMAT['GT'][sample][0] "
+            f"for x in FORMAT['GT'][sample][1:])",
+            env,
+            {},
+        ),
+        "is_ref": eval(
+            f"lambda sample: " f"all(x == 0 " f"for x in FORMAT['GT'][sample][1:])",
+            env,
+            {},
+        ),
+        "is_var": eval(
+            f"lambda sample: " f"any(x != 0 " f"for x in FORMAT['GT'][sample][1:])",
+            env,
+            {},
+        ),
+    }

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -171,6 +171,23 @@ class Environment(dict):
         self._globals = {}
         # We use self + self.func as a closure.
         self._globals = allowed_globals.copy()
+        custom_functions = {
+            "count_hom": eval(
+                "lambda: "
+                "sum(all(x == FORMAT['GT'][s][0] for x in FORMAT['GT'][s][1:]) "
+                "for s in SAMPLES)",
+                self,
+                {},
+            ),
+            "count_het": eval(
+                "lambda: "
+                "sum(any(x != FORMAT['GT'][s][0] for x in FORMAT['GT'][s][1:]) "
+                "for s in SAMPLES)",
+                self,
+                {},
+            ),
+        }
+        self._globals.update(custom_functions)
         self._func = eval(f"lambda: {expression}", self, {})
 
         self._getters = {


### PR DESCRIPTION
`SnpSift` has some "custom" functions for counting the number of homo-/heterozygous samples, as well as checking if a sample's genotype is hom/het/var/ref. So I implemented them for vembrane, too. Not sure if I this implementation is correct and also not quite sure if this is the best way to include such functions.
I could also think of having a better Format/Sample class which allows for nicer and more expressive syntax, e.g. `SAMPLES[0].is_hom()`.