### PR TITLE
Add --version option

### DIFF
--- a/vembrane/cli.py
+++ b/vembrane/cli.py
@@ -7,7 +7,7 @@ from . import __version__
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--version", "-v", action="version", version=f"%(prog)s {__version__}"
+        "--version", action="version", version=f"%(prog)s {__version__}"
     )
     subparsers = parser.add_subparsers(
         dest="command", description="valid subcommands", required=True

--- a/vembrane/cli.py
+++ b/vembrane/cli.py
@@ -1,10 +1,14 @@
 import argparse
 
 from .modules import filter, table
+from . import __version__
 
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version", "-v", action="version", version=f"%(prog)s {__version__}"
+    )
     subparsers = parser.add_subparsers(
         dest="command", description="valid subcommands", required=True
     )


### PR DESCRIPTION
This PR adds a `--version` (and the short `-v`) to the vembrane *base* parser, i.e. `vembrane --version` will output `vembrane {version}`; `vembrane filter|table --version` will *not* work.