### PR TITLE
Format containment fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vembrane"
-version = "0.5.2"
+version = "0.5.3"
 description = "Filter VCF/BCF files with Python expressions."
 authors = ["Till Hartmann"]
 readme = "README.md"

--- a/vembrane/errors.py
+++ b/vembrane/errors.py
@@ -13,7 +13,7 @@ class UnknownAnnotation(VembraneError):
         self.key = key
 
 
-class UnknownSample(VembraneError):
+class UnknownSample(VembraneError, KeyError):
     """Unknown Sample"""
 
     def __init__(self, record, sample, msg=None):
@@ -24,7 +24,7 @@ class UnknownSample(VembraneError):
         self.field = sample
 
 
-class UnknownFormatField(VembraneError):
+class UnknownFormatField(VembraneError, KeyError):
     """Unknown FORMAT key"""
 
     def __init__(self, record, field, msg=None):


### PR DESCRIPTION
Sometimes VCF files will have records with different FORMAT specs. For example, one record may list `GT:DP` while another only lists `GT`. In those cases, the expression should at least contain a check for `DP`, such as `"DP" in FORMAT and FORMAT["DP"] > 0`. However, since `Formats.__getitem__` did not raise a `KeyError` but a `UnknownFormatField` which up until now was only a `VembraneError`, the `"DP" in FORMAT` check failed instead of returning `False`. Now, `UnknownFormatField` is additionally a `KeyError`, so the check will now work, while the access with `FORMAT["DP"]` will still fail.