### PR TITLE
Implement `hash` for NoValue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    rev: 3.8.4
     hooks:
       - id: flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.4.0
     hooks:
       - id: check-byte-order-marker
         exclude: ^tests/.*

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -33,6 +33,9 @@ class NoValue:
     def __repr__(self):
         return f"{self.__class__.__name__}()"
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
 
 NA = NoValue()
 


### PR DESCRIPTION
This PR implements `hash` for NoValue, such that membership tests akin to `NA in ANN["SYMBOL"]` always evaluate to `False`.
However, this is only the case for sets/dicts that derive from `NoValueDict`, i.e.: `INFO`, `FORMAT`, `ANN`. But as long as nobody inserts `NA` into a non-`NoValueDict` manually, this should be fine.

(accidentally also updates pre-commit-hook versions)