### PR TITLE
Add __len__ to InfoTuple

### DIFF
--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -66,6 +66,9 @@ class InfoTuple:
     def __repr__(self):
         return f"{self.__class__.__name__}(values={self.values!r})"
 
+    def __len__(self):
+        return len(self.values)
+
 
 IntFloatStr = Union[int, float, str]
 


### PR DESCRIPTION
This PR adds the `__len__` method to the `InfoTuple` class such that one can write `len(INFO["foo"])`. I briefly considered inheriting from tuple, but since that may have some unwanted side-effects, decided against that.