### PR TITLE
Fix subsequent ALT accesses yielding list not str

### DIFF
--- a/tests/testcases/test_alt_allele_multiple_access/config.yaml
+++ b/tests/testcases/test_alt_allele_multiple_access/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: 'ALT == "C" and ALT == "C"'

--- a/tests/testcases/test_alt_allele_multiple_access/expected.vcf
+++ b/tests/testcases/test_alt_allele_multiple_access/expected.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.3
+##contig=<ID=1,length=2>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	1	.	A	C	.	.	.

--- a/tests/testcases/test_alt_allele_multiple_access/test.vcf
+++ b/tests/testcases/test_alt_allele_multiple_access/test.vcf
@@ -1,0 +1,5 @@
+##fileformat=VCFv4.3
+##contig=<ID=1,length=2>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	1	.	A	C	.	.	.
+1	2	.	A	G	.	.	.


### PR DESCRIPTION
Reported by @christopher-schroeder.
A filter expression like `ALT == "C" and ALT == "C"` for an entry with ALT allele `C` resulted an evaluated expression `"C" == "C" and ["C"] == "C"` (i.e., erroneously yielding `False`) because we cached the whole ALT list instead of just the first value.