### PR TITLE
Add more annotation types

### DIFF
--- a/Types.md
+++ b/Types.md
@@ -97,6 +97,7 @@ Annotations with type `str`:
 |`USED_REF`|`USED_REF`|`str`|Reference allele as used to get consequences| |
 |`AMBIGUITY`|`AMBIGUITY`|`str`|IUPAC allele ambiguity code| |
 |`HGNC_ID`|`HGNC_ID`|`str`| | |
+|`MANE`|`MANE`|`str`|Matched Annotation from NCBI and EMBL-EBI (MANE).| |
 |`MANE_SELECT`|`MANE_SELECT`|`str`|Matched Annotation from NCBI and EMBL-EBI (MANE) canonical transcript.| |
 |`MANE_PLUS_CLINICAL`|`MANE_PLUS_CLINICAL`|`str`|MANE transcripts beyond MANE_SELECT that are clinically relevant.| |
 |`GO`|`GO`|`str`|Gene ontology (GO) terms.| |

--- a/Types.md
+++ b/Types.md
@@ -97,7 +97,9 @@ Annotations with type `str`:
 |`USED_REF`|`USED_REF`|`str`|Reference allele as used to get consequences| |
 |`AMBIGUITY`|`AMBIGUITY`|`str`|IUPAC allele ambiguity code| |
 |`HGNC_ID`|`HGNC_ID`|`str`| | |
-|`MANE`|`MANE`|`str`|Matched Annotation from NCBI and EMBL-EBI (MANE).| |
+|`MANE_SELECT`|`MANE_SELECT`|`str`|Matched Annotation from NCBI and EMBL-EBI (MANE) canonical transcript.| |
+|`MANE_PLUS_CLINICAL`|`MANE_PLUS_CLINICAL`|`str`|MANE transcripts beyond MANE_SELECT that are clinically relevant.| |
+|`GO`|`GO`|`str`|Gene ontology (GO) terms.| |
 |`miRNA`|`miRNA`|`str`|Determines where in the secondary structure of a miRNA a variant falls| |
 
 

--- a/Types.md
+++ b/Types.md
@@ -59,6 +59,8 @@ Annotations with custom types:
 |`Codons`|`Codons`|`List[str]`|Reference and variant codon sequence| |
 |`Existing_variation`|`Existing_variation`|`List[str]`|Identifier(s) of co-located known variants| |
 |`LoFtool`|`LoFtool`|`float`|Provides a rank of genic intolerance and consequent susceptibility to disease based on the ratio of Loss-of-function (LoF) to synonymous mutations."| |
+|`REVEL`|`REVEL`|`float`|Estimate of the pathogenicity of missense variants.| |
+|`ExACpLI`|`ExACpLI`|`float`|Probabililty of a gene being loss-of-function intolerant (pLI).| |
 
 
 Annotations with type `str`:

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -290,7 +290,10 @@ KNOWN_ANN_TYPE_MAP_SNPEFF = {
     "CDS.pos / CDS.length": AnnotationEntry("CDS", PosRange.from_snpeff_str),
     "AA.pos / AA.length": AnnotationEntry("AA", PosRange.from_snpeff_str),
     "Distance": AnnotationEntry("Distance", str),
-    "ERRORS / WARNINGS / INFO": AnnotationListEntry("ERRORS / WARNINGS / INFO", "/",),
+    "ERRORS / WARNINGS / INFO": AnnotationListEntry(
+        "ERRORS / WARNINGS / INFO",
+        "/",
+    ),
 }
 
 # fields, types and description taken from:

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -656,6 +656,9 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     # TODO HGNC_ID description
     "HGNC_ID": AnnotationEntry("HGNC_ID"),
+    "MANE": AnnotationEntry(
+        "MANE", description="Matched Annotation from NCBI and EMBL-EBI (MANE)."
+    ),
     "MANE_SELECT": AnnotationEntry(
         "MANE_SELECT",
         description="Matched Annotation from NCBI and EMBL-EBI (MANE) "

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -676,6 +676,20 @@ KNOWN_ANN_TYPE_MAP_VEP = {
         "consequent susceptibility to disease based on the ratio of Loss-of-function "
         "(LoF) to synonymous mutations.",
     ),
+    "REVEL": AnnotationEntry(
+        "REVEL",
+        typefunc=float,
+        description="Estimate of the pathogenicity of missense variants. "
+        "Please cite the REVEL publication alongside the VEP if you use this "
+        "resource: https://www.ncbi.nlm.nih.gov/pubmed/27666373"
+    ),
+    "ExACpLI": AnnotationEntry(
+        "ExACpLI",
+        typefunc=float,
+        description="Probabililty of a gene being loss-of-function intolerant (pLI). "
+        "Please cite the respective ExAC publication alongside the VEP if you use this "
+        "resource: https://www.ncbi.nlm.nih.gov/pubmed/27535533"
+    ),
 }
 
 KNOWN_ANN_TYPE_MAP = {**KNOWN_ANN_TYPE_MAP_SNPEFF, **KNOWN_ANN_TYPE_MAP_VEP}

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -290,10 +290,7 @@ KNOWN_ANN_TYPE_MAP_SNPEFF = {
     "CDS.pos / CDS.length": AnnotationEntry("CDS", PosRange.from_snpeff_str),
     "AA.pos / AA.length": AnnotationEntry("AA", PosRange.from_snpeff_str),
     "Distance": AnnotationEntry("Distance", str),
-    "ERRORS / WARNINGS / INFO": AnnotationListEntry(
-        "ERRORS / WARNINGS / INFO",
-        "/",
-    ),
+    "ERRORS / WARNINGS / INFO": AnnotationListEntry("ERRORS / WARNINGS / INFO", "/",),
 }
 
 # fields, types and description taken from:
@@ -661,7 +658,7 @@ KNOWN_ANN_TYPE_MAP_VEP = {
         description="Matched Annotation from NCBI and EMBL-EBI (MANE) "
         "canonical transcript, indicated by the respective RefSeq NM ID."
         "For more info, see: "
-        "https://www.ensembl.org/info/genome/genebuild/mane.html"
+        "https://www.ensembl.org/info/genome/genebuild/mane.html",
     ),
     "MANE_PLUS_CLINICAL": AnnotationEntry(
         "MANE_PLUS_CLINICAL",
@@ -669,12 +666,9 @@ KNOWN_ANN_TYPE_MAP_VEP = {
         "transcripts beyond MANE_SELECT, that are important clinically. "
         "Indicated by their RefSeq NM IDs."
         "For more info, see: "
-        "https://www.ensembl.org/info/genome/genebuild/mane.html"
+        "https://www.ensembl.org/info/genome/genebuild/mane.html",
     ),
-    "GO": AnnotationEntry(
-        "GO",
-        description="Gene ontology (GO) terms."
-    ),
+    "GO": AnnotationEntry("GO", description="Gene ontology (GO) terms."),
     "miRNA": AnnotationEntry(
         "miRNA",
         description="Determines where in the secondary structure of a miRNA "
@@ -697,14 +691,14 @@ KNOWN_ANN_TYPE_MAP_VEP = {
         typefunc=float,
         description="Estimate of the pathogenicity of missense variants. "
         "Please cite the REVEL publication alongside the VEP if you use this "
-        "resource: https://www.ncbi.nlm.nih.gov/pubmed/27666373"
+        "resource: https://www.ncbi.nlm.nih.gov/pubmed/27666373",
     ),
     "ExACpLI": AnnotationEntry(
         "ExACpLI",
         typefunc=float,
         description="Probabililty of a gene being loss-of-function intolerant (pLI). "
         "Please cite the respective ExAC publication alongside the VEP if you use this "
-        "resource: https://www.ncbi.nlm.nih.gov/pubmed/27535533"
+        "resource: https://www.ncbi.nlm.nih.gov/pubmed/27535533",
     ),
 }
 

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -656,8 +656,24 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     # TODO HGNC_ID description
     "HGNC_ID": AnnotationEntry("HGNC_ID"),
-    "MANE": AnnotationEntry(
-        "MANE", description="Matched Annotation from NCBI and EMBL-EBI (MANE)."
+    "MANE_SELECT": AnnotationEntry(
+        "MANE_SELECT",
+        description="Matched Annotation from NCBI and EMBL-EBI (MANE) "
+        "canonical transcript, indicated by the respective RefSeq NM ID."
+        "For more info, see: "
+        "https://www.ensembl.org/info/genome/genebuild/mane.html"
+    ),
+    "MANE_PLUS_CLINICAL": AnnotationEntry(
+        "MANE_PLUS_CLINICAL",
+        description="Matched Annotation from NCBI and EMBL-EBI (MANE) "
+        "transcripts beyond MANE_SELECT, that are important clinically. "
+        "Indicated by their RefSeq NM IDs."
+        "For more info, see: "
+        "https://www.ensembl.org/info/genome/genebuild/mane.html"
+    ),
+    "GO": AnnotationEntry(
+        "GO",
+        description="Gene ontology (GO) terms."
     ),
     "miRNA": AnnotationEntry(
         "miRNA",


### PR DESCRIPTION
Adds REVEL, ExACpLI and GO to `KNOWN_ANN_TYPE_MAP_VEP`, including descriptions in `Types.md`. Turns `MANE` entry into separate entries for `MANE_SELECT` and `MANE_PLUS_CLINICAL`.