### PR TITLE
Add `without_na`, `replace_na` and common functions from python's `statistics` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The filter expression can be any valid python expression that evaluates to `bool
  * `bool`, `chr`, `float`, `int`, `ord`, `str`
  * Any function or symbol from [`math`](https://docs.python.org/3/library/math.html)
  * Regular expressions via [`re`](https://docs.python.org/3/library/re.html)
+ * custom functions:
+   * `filter_na` (keep only values that are not `NA`)
+   *  `mean` (calculate the mean of an iterable of values)
 
 ### Available fields
 The following VCF fields can be accessed in the filter expression:
@@ -93,6 +96,8 @@ Since you may want to use the regex module to search for matches, `NA` also acts
 *Explicitly* handling missing/optional values in INFO or FORMAT fields can be done by checking for NA, e.g.: `INFO["DP"] is NA`.
 
 Handling missing/optional values in fields other than INFO or FORMAT can be done by checking for None, e.g `ID is not None`.
+
+Sometimes, multi-valued fields may contain missing values; in this case, the `filter_na` function can be convenient, for example: `mean(filter_na(FORMAT['DP'][s] for s in SAMPLES)) > 2.3`.
 
 ### Auxiliary files
 `vembrane` supports additional files, such as lists of genes or ids with the `--aux NAME path/to/file` option. The file should contain one item per line and is parsed as a set. For example `vembrane filter --aux genes genes.txt "ANN['SYMBOL'] in AUX['genes']" variants.vcf` will keep only records where the annotated symbol is in the set specified in `genes.txt`.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ The filter expression can be any valid python expression that evaluates to `bool
  * Any function from [`statistics`](https://docs.python.org/3/library/statistics.html)
  * Regular expressions via [`re`](https://docs.python.org/3/library/re.html)
  * custom functions:
-   * `filter_na` (keep only values that are not `NA`)
-   *  `mean` (calculate the mean of an iterable of values)
+   * `without_na` (keep only values that are not `NA`)
+   * genotype related:
+     * `count_hom`, `count_het` , `count_any_ref`, `count_any_var`, `count_hom_ref`, `count_hom_var`
+     * `is_hom`, `is_het`, `is_hom_ref` , `is_hom_var`
+     * `has_ref`, `has_var`
 
 ### Available fields
 The following VCF fields can be accessed in the filter expression:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The filter expression can be any valid python expression that evaluates to `bool
  * Any function from [`statistics`](https://docs.python.org/3/library/statistics.html)
  * Regular expressions via [`re`](https://docs.python.org/3/library/re.html)
  * custom functions:
-   * `without_na` (keep only values that are not `NA`)
-   * `replace_na` (replace values that are `NA` with some other fixed value)
+   * `without_na(values: Iterable[Any]) -> Iterable[Any]` (keep only values that are not `NA`)
+   * `replace_na(values: Iterable[Any], replacement: Any) -> Iterable[Any]` (replace values that are `NA` with some other fixed value)
    * genotype related:
      * `count_hom`, `count_het` , `count_any_ref`, `count_any_var`, `count_hom_ref`, `count_hom_var`
      * `is_hom`, `is_het`, `is_hom_ref` , `is_hom_var`
@@ -102,7 +102,7 @@ Since you may want to use the regex module to search for matches, `NA` also acts
 
 Handling missing/optional values in fields other than INFO or FORMAT can be done by checking for None, e.g `ID is not None`.
 
-Sometimes, multi-valued fields may contain missing values; in this case, the `without_na` function can be convenient, for example: `mean(without_na(FORMAT['DP'][s] for s in SAMPLES)) > 2.3`.
+Sometimes, multi-valued fields may contain missing values; in this case, the `without_na` function can be convenient, for example: `mean(without_na(FORMAT['DP'][s] for s in SAMPLES)) > 2.3`. It is also possible to replace `NA` with some constant value with the `replace_na` function: `mean(replace_na((FORMAT['DP'][s] for s in SAMPLES), 0.0)) > 2.3`
 
 ### Auxiliary files
 `vembrane` supports additional files, such as lists of genes or ids with the `--aux NAME path/to/file` option. The file should contain one item per line and is parsed as a set. For example `vembrane filter --aux genes genes.txt "ANN['SYMBOL'] in AUX['genes']" variants.vcf` will keep only records where the annotated symbol is in the set specified in `genes.txt`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The filter expression can be any valid python expression that evaluates to `bool
  * Regular expressions via [`re`](https://docs.python.org/3/library/re.html)
  * custom functions:
    * `without_na` (keep only values that are not `NA`)
+   * `replace_na` (replace values that are `NA` with some other fixed value)
    * genotype related:
      * `count_hom`, `count_het` , `count_any_ref`, `count_any_var`, `count_hom_ref`, `count_hom_var`
      * `is_hom`, `is_het`, `is_hom_ref` , `is_hom_var`

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The filter expression can be any valid python expression that evaluates to `bool
  * `dict`, `list`, `set`, `tuple`
  * `bool`, `chr`, `float`, `int`, `ord`, `str`
  * Any function or symbol from [`math`](https://docs.python.org/3/library/math.html)
+ * Any function from [`statistics`](https://docs.python.org/3/library/statistics.html)
  * Regular expressions via [`re`](https://docs.python.org/3/library/re.html)
  * custom functions:
    * `filter_na` (keep only values that are not `NA`)
@@ -97,7 +98,7 @@ Since you may want to use the regex module to search for matches, `NA` also acts
 
 Handling missing/optional values in fields other than INFO or FORMAT can be done by checking for None, e.g `ID is not None`.
 
-Sometimes, multi-valued fields may contain missing values; in this case, the `filter_na` function can be convenient, for example: `mean(filter_na(FORMAT['DP'][s] for s in SAMPLES)) > 2.3`.
+Sometimes, multi-valued fields may contain missing values; in this case, the `without_na` function can be convenient, for example: `mean(without_na(FORMAT['DP'][s] for s in SAMPLES)) > 2.3`.
 
 ### Auxiliary files
 `vembrane` supports additional files, such as lists of genes or ids with the `--aux NAME path/to/file` option. The file should contain one item per line and is parsed as a set. For example `vembrane filter --aux genes genes.txt "ANN['SYMBOL'] in AUX['genes']" variants.vcf` will keep only records where the annotated symbol is in the set specified in `genes.txt`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vembrane"
-version = "0.8.0"
+version = "0.9.0"
 description = "Filter VCF/BCF files with Python expressions."
 authors = ["Till Hartmann", "Christopher Schröder", "Johannes Köster", "Jan Forster", "Marcel Bargull", "Felix Mölder", "Elias Kuthe", "David Lähnemann"]
 readme = "README.md"

--- a/tests/testcases/test_replace_na/config.yaml
+++ b/tests/testcases/test_replace_na/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: mean(replace_na((FORMAT['DP'][s] for s in SAMPLES), 0)) == 10.0

--- a/tests/testcases/test_replace_na/expected.vcf
+++ b/tests/testcases/test_replace_na/expected.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3
+chr18	27963423	.	G	A	276	PASS		DP	10	20	.

--- a/tests/testcases/test_replace_na/test.vcf
+++ b/tests/testcases/test_replace_na/test.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3
+chr18	27963423	.	G	A	276	PASS		DP	10	20	.
+chr18	27963423	.	G	A	276	PASS		DP	.	.	5

--- a/tests/testcases/test_statistics/config.yaml
+++ b/tests/testcases/test_statistics/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: mean(FORMAT['VALS']['Sample']) == 1. and median(FORMAT['VALS']['Sample']) == 1

--- a/tests/testcases/test_statistics/expected.vcf
+++ b/tests/testcases/test_statistics/expected.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=VALS,Number=10,Type=Integer,Description="Some values">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample
+chr18	27963423	.	G	A	276	PASS		VALS	0,0,1,1,1,1,1,1,2,2

--- a/tests/testcases/test_statistics/test.vcf
+++ b/tests/testcases/test_statistics/test.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=VALS,Number=10,Type=Integer,Description="Some values">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample
+chr18	27963423	.	G	A	276	PASS		VALS	0,0,1,1,1,1,1,1,2,2
+chr18	27963423	.	G	A	276	PASS		VALS	0,0,0,0,0,0,0,0,0,10

--- a/tests/testcases/test_without_na/config.yaml
+++ b/tests/testcases/test_without_na/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: mean(without_na(FORMAT['DP'][s] for s in SAMPLES)) == 15.0

--- a/tests/testcases/test_without_na/expected.vcf
+++ b/tests/testcases/test_without_na/expected.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3
+chr18	27963423	.	G	A	276	PASS		DP	10	20	.

--- a/tests/testcases/test_without_na/test.vcf
+++ b/tests/testcases/test_without_na/test.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3
+chr18	27963423	.	G	A	276	PASS		DP	10	20	.
+chr18	27963423	.	G	A	276	PASS		DP	.	.	5

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -1,15 +1,15 @@
 import math
 import re
 
+from typing import Dict, Any, Iterable, SupportsFloat
+
+from .ann_types import NA
+
 # The builtins list below was generated with:
 #    python -c 'print(
 #        *sorted(o for o in dir(__builtins__) if o.islower() and not o.startswith("_")),
 #        sep="\n",
 #    )'
-from typing import Dict, Any
-
-from .ann_types import NA
-
 _builtins = {
     obj.__name__: obj
     for obj in (
@@ -95,6 +95,25 @@ _math_exports = {
     name: mod for name, mod in vars(math).items() if not name.startswith("__")
 }
 
+
+def filter_na(values: Iterable[Any]) -> "filter":
+    return filter(lambda v: v is not NA, values)
+
+
+def mean(values: Iterable[SupportsFloat]) -> float:
+    sum = 0.0
+    count = 0
+    for v in values:
+        sum += float(v)
+        count += 1
+    if count > 0:
+        return sum / float(count)
+    else:
+        return float("nan")
+
+
+_additional_functions = {"mean": mean, "filter_na": filter_na}
+
 _explicit_clear = {
     "__builtins__": {},
     "__builtin__": {},
@@ -109,6 +128,7 @@ allowed_globals = {
     **_modules,
     **_math_exports,
     **_explicit_clear,
+    **_additional_functions,
     "NA": NA,
 }
 

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -98,13 +98,6 @@ _math_exports = {
 
 
 _statistics_whitelist = {
-    "hypot",
-    "sqrt",
-    "fabs",
-    "exp",
-    "erf",
-    "log",
-    "fsum",
     "mean",
     "fmean",
     "geometric_mean",
@@ -120,6 +113,9 @@ _statistics_whitelist = {
     "pvariance",
     "stdev",
     "pstdev",
+    "covariance",
+    "correlation",
+    "linear_regression",
 }
 
 _statistics_exports = {

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -1,7 +1,8 @@
 import math
 import re
+import statistics
 
-from typing import Dict, Any, Iterable, SupportsFloat
+from typing import Dict, Any, Iterable
 
 from .ann_types import NA
 
@@ -96,23 +97,41 @@ _math_exports = {
 }
 
 
-def filter_na(values: Iterable[Any]) -> "filter":
+_statistics_whitelist = {
+    "hypot",
+    "sqrt",
+    "fabs",
+    "exp",
+    "erf",
+    "log",
+    "fsum",
+    "mean",
+    "fmean",
+    "geometric_mean",
+    "harmonic_mean",
+    "median",
+    "median_low",
+    "median_high",
+    "median_grouped",
+    "mode",
+    "multimode",
+    "quantiles",
+    "variance",
+    "pvariance",
+    "stdev",
+    "pstdev",
+}
+
+_statistics_exports = {
+    name: mod for name, mod in vars(statistics).items() if name in _statistics_whitelist
+}
+
+
+def without_na(values: Iterable[Any]) -> "filter":
     return filter(lambda v: v is not NA, values)
 
 
-def mean(values: Iterable[SupportsFloat]) -> float:
-    sum = 0.0
-    count = 0
-    for v in values:
-        sum += float(v)
-        count += 1
-    if count > 0:
-        return sum / float(count)
-    else:
-        return float("nan")
-
-
-_additional_functions = {"mean": mean, "filter_na": filter_na}
+_additional_functions = {"without_na": without_na}
 
 _explicit_clear = {
     "__builtins__": {},
@@ -127,8 +146,9 @@ allowed_globals = {
     **_builtins,
     **_modules,
     **_math_exports,
-    **_explicit_clear,
+    **_statistics_exports,
     **_additional_functions,
+    **_explicit_clear,
     "NA": NA,
 }
 

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -97,29 +97,10 @@ _math_exports = {
 }
 
 
-_statistics_whitelist = {
-    "mean",
-    "fmean",
-    "geometric_mean",
-    "harmonic_mean",
-    "median",
-    "median_low",
-    "median_high",
-    "median_grouped",
-    "mode",
-    "multimode",
-    "quantiles",
-    "variance",
-    "pvariance",
-    "stdev",
-    "pstdev",
-    "covariance",
-    "correlation",
-    "linear_regression",
-}
-
 _statistics_exports = {
-    name: mod for name, mod in vars(statistics).items() if name in _statistics_whitelist
+    name: mod
+    for name, mod in vars(statistics).items()
+    if name in statistics.__all__ and name[0].islower()
 }
 
 

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -127,7 +127,15 @@ def without_na(values: Iterable[Any]) -> "filter":
     return filter(lambda v: v is not NA, values)
 
 
-_additional_functions = {"without_na": without_na}
+def replace_na(values: Iterable[Any], replacement: Any) -> Iterable[Any]:
+    for v in values:
+        if v is not NA:
+            yield v
+        else:
+            yield replacement
+
+
+_additional_functions = {"without_na": without_na, "replace_na": replace_na}
 
 _explicit_clear = {
     "__builtins__": {},


### PR DESCRIPTION
Rationale behind `without_na`: Sometimes fields are incorrectly specified and have NAs even though they should not; for expressions like `sum(FORMAT['DP'][s] for s in SAMPLES) > 5` this leads to `TypeErrors`. If you have such a case, `without_na` can increase convenience: `sum(without_na(FORMAT['DP'][s] for s in SAMPLES)) > 5`. Its definition is straightforward:
```python
def without_na(values: Iterable[Any]) -> "filter":
    return filter(lambda v: v is not NA, values)
```

Rationale behind `replace_na`: Similar to `without_na`, but sometimes there may be a reasonable value to default to, e.g.: `sum(replace_na((FORMAT["DP"][s] for s in SAMPLES), 0))`.


~~Rationale behind why we supply `mean` as a custom function instead of e.g. using numpy.mean or exposing numpy itself as `np` in the globals:~~

~~1. numpy is a large dependency~~
~~2. numpy's functions operate on numpy arrays, so in the example above, the generator expression will first have to be converted to a list comprehension (resulting in an allocation) and then is converted to a numpy array internally, and only then does the actual computation happen. This is about twice as slow as the generator version (on my machine and test dataset with 3 samples).~~

~~Examples:~~
~~- custom mean: `mean(without_na(FORMAT['DP'][s] for s in SAMPLES)) > 2.4`~~
~~- numpy mean with without_na:  `np.mean(list(without_na(FORMAT['DP'][s] for s in SAMPLES))) > 2.4`~~
~~- numpy mean without without_na  `np.mean([v for s in SAMPLES if (v:= FORMAT['DP'][s]) is not NA]) > 2.4`~~

~~However, if we did include numpy in the globals, we would instantly get access to all of its functionality (including standard deviations etc). Perhaps there are alternatives to numpy which work well for generators or short lists?~~

We're now using functions from python's `statistics` module (available from python 3.4 onwards).
This for example allows writing `mean(without_na(FORMAT['DP'][s] for s in SAMPLES)) > 2.4`