### PR TITLE
pyproject.toml adjustments, bump patch version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -333,7 +333,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "d09cead8a8d2ad869a125b9ae6eaef3f78f3890940b15f152bcf6d9f540ce0f5"
+content-hash = "59b17edfa0aec17f9c846ba2a8efe72c63e577a5abaefa1fda0f0fe1aadca436"
 
 [metadata.files]
 asttokens = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vembrane"
-version = "0.10.0"
+version = "0.10.1"
 description = "Filter VCF/BCF files with Python expressions."
 authors = ["Till Hartmann", "Christopher Schröder", "Johannes Köster", "Jan Forster", "Marcel Bargull", "Felix Mölder", "Elias Kuthe", "David Lähnemann"]
 readme = "README.md"
@@ -14,14 +14,14 @@ vembrane = 'vembrane.cli:main'
 python = ">=3.8"
 pysam = "^0.19"
 pyyaml = "^6.0"
-importlib_metadata = {version = "^1.7.0", python = "<3.8"}
 asttokens = "^2.0"
-numpy = {version = "^1.23", python = ">=3.7"}
+numpy = { version = "^1.23", python = ">=3.8" }
 intervaltree = "^3.1"
+
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"
 pre-commit = "^2.20"
-black = { version = "^22.6", python = "^3.7" }
+black = { version = "^22.6", python = "^3.8" }
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Some version ranges still included python 3.7, this bumps these to 3.8