### PR TITLE
Replace float constants in expressions with IEEE-754-1985 32bit float constants.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       id: get-python-versions-action
       with:
         min-version: 3.8
+        max-version: 3.10.5
 
   test:
     needs: [get-python-versions]

--- a/tests/testcases/test_float32/config.yaml
+++ b/tests/testcases/test_float32/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: '0.6 < INFO["FLOAT"] <= 0.9'

--- a/tests/testcases/test_float32/expected.vcf
+++ b/tests/testcases/test_float32/expected.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.1
+##fileDate=20220408
+##contig=<ID=chr1,length=3>
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=FLOAT,Number=1,Type=Float,Description="One single float">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample
+chr1	2	.	G	A	276	PASS	FLOAT=0.7	.	.
+chr1	3	.	G	A	276	PASS	FLOAT=0.8	.	.
+chr1	3	.	G	A	276	PASS	FLOAT=0.9	.	.

--- a/tests/testcases/test_float32/test.vcf
+++ b/tests/testcases/test_float32/test.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##fileDate=20220408
+##contig=<ID=chr1,length=3>
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=FLOAT,Number=1,Type=Float,Description="One single float">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample
+chr1	1	.	G	A	276	PASS	FLOAT=0.6	.	.
+chr1	2	.	G	A	276	PASS	FLOAT=0.7	.	.
+chr1	3	.	G	A	276	PASS	FLOAT=0.8	.	.
+chr1	3	.	G	A	276	PASS	FLOAT=0.9	.	.

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -3,6 +3,8 @@ from sys import stderr
 from typing import Union, Iterable, Tuple, Dict, Callable, Any
 import re
 
+import numpy
+
 from .errors import MoreThanOneAltAllele, NotExactlyOneValue
 
 
@@ -70,7 +72,7 @@ class InfoTuple:
         return len(self.values)
 
 
-IntFloatStr = Union[int, float, str]
+IntFloatStr = Union[int, float, str, numpy.floating]
 
 
 def type_info(value, number=".", field=None, record_idx=None):
@@ -225,17 +227,25 @@ class RangeTotal(object):
             return cls(range(r[0], r[1] + 1), int(v[1]))
         else:
             raise ValueError(
-                "Found more than two values separated by '-', expected only a single int, or two ints separated by '-'."
+                "Found more than two values separated by '-', "
+                "expected only a single int, or two ints separated by '-'."
             )
 
     def __str__(self):
         if len(self.range) == 1:
             return f"number / total: {self.range.start} / {self.total}"
         else:
-            return f"range / total: {self.range.start} - {self.range.stop - 1} / {self.total}"
+            return (
+                f"range / total: "
+                f"{self.range.start} - {self.range.stop - 1} / {self.total}"
+            )
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(range=range({self.range.start!r}, {self.range.stop!r}), total={self.total!r})"
+        return (
+            f"{self.__class__.__name__}"
+            f"(range=range({self.range.start!r}, {self.range.stop!r}), "
+            f"total={self.total!r})"
+        )
 
 
 class AnnotationRangeTotalEntry(AnnotationEntry):
@@ -274,7 +284,7 @@ class AnnotationPredictionScoreEntry(AnnotationEntry):
     def __init__(self, name: str, **kwargs):
         def typefunc(x: str) -> Dict[str, float]:
             match = PREDICTION_SCORE_REGEXP.findall(x)[0]
-            return {match[0]: float(match[1])}
+            return {match[0]: numpy.float32(match[1])}
 
         super().__init__(name, typefunc=typefunc, nafunc=lambda: dict(), **kwargs)
 
@@ -426,7 +436,7 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     "MOTIF_SCORE_CHANGE": AnnotationEntry(
         "MOTIF_SCORE_CHANGE",
-        float,
+        numpy.float32,
         description="The difference in motif score of the reference and variant "
         "sequences for the TFBP",
     ),
@@ -466,113 +476,113 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     #     "FREQS", description="Frequencies of overlapping variants used in filtering"
     # ),
     "AF": AnnotationEntry(
-        "AF", float, description="Frequency of existing variant in 1000 Genomes"
+        "AF", numpy.float32, description="Frequency of existing variant in 1000 Genomes"
     ),
     "AFR_AF": AnnotationEntry(
         "AFR_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "African population",
     ),
     "AMR_AF": AnnotationEntry(
         "AMR_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "American population",
     ),
     "ASN_AF": AnnotationEntry(
         "ASN_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "Asian population",
     ),
     "EUR_AF": AnnotationEntry(
         "EUR_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "European population",
     ),
     "EAS_AF": AnnotationEntry(
         "EAS_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "East Asian population",
     ),
     "SAS_AF": AnnotationEntry(
         "SAS_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "South Asian population",
     ),
     "AA_AF": AnnotationEntry(
         "AA_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in NHLBI-ESP "
         "African American population",
     ),
     "EA_AF": AnnotationEntry(
         "EA_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in NHLBI-ESP "
         "European American population",
     ),
     "gnomAD_AF": AnnotationEntry(
         "gnomAD_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "combined population",
     ),
     "gnomAD_AFR_AF": AnnotationEntry(
         "gnomAD_AFR_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "African/American population",
     ),
     "gnomAD_AMR_AF": AnnotationEntry(
         "gnomAD_AMR_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "American population",
     ),
     "gnomAD_ASJ_AF": AnnotationEntry(
         "gnomAD_ASJ_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "Ashkenazi Jewish population",
     ),
     "gnomAD_EAS_AF": AnnotationEntry(
         "gnomAD_EAS_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "East Asian population",
     ),
     "gnomAD_FIN_AF": AnnotationEntry(
         "gnomAD_FIN_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "Finnish population",
     ),
     "gnomAD_NFE_AF": AnnotationEntry(
         "gnomAD_NFE_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "Non-Finnish European population",
     ),
     "gnomAD_OTH_AF": AnnotationEntry(
         "gnomAD_OTH_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "combined other combined populations",
     ),
     "gnomAD_SAS_AF": AnnotationEntry(
         "gnomAD_SAS_AF",
-        float,
+        numpy.float32,
         description="Frequency of existing variant in gnomAD exomes "
         "South Asian population",
     ),
     "MAX_AF": AnnotationEntry(
         "MAX_AF",
-        float,
+        numpy.float32,
         description="Maximum observed allele frequency in "
         "1000 Genomes, ESP and gnomAD",
     ),
@@ -669,7 +679,7 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     "OverlapPC": AnnotationEntry(
         "OverlapPC",
-        float,
+        numpy.float32,
         description="Percentage of corresponding structural variation feature "
         "overlapped by the given input",
     ),
@@ -720,21 +730,21 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     "LoFtool": AnnotationEntry(
         "LoFtool",
-        typefunc=float,
+        typefunc=numpy.float32,
         description="Provides a rank of genic intolerance and "
         "consequent susceptibility to disease based on the ratio of Loss-of-function "
         "(LoF) to synonymous mutations.",
     ),
     "REVEL": AnnotationEntry(
         "REVEL",
-        typefunc=float,
+        typefunc=numpy.float32,
         description="Estimate of the pathogenicity of missense variants. "
         "Please cite the REVEL publication alongside the VEP if you use this "
         "resource: https://www.ncbi.nlm.nih.gov/pubmed/27666373",
     ),
     "ExACpLI": AnnotationEntry(
         "ExACpLI",
-        typefunc=float,
+        typefunc=numpy.float32,
         description="Probabililty of a gene being loss-of-function intolerant (pLI). "
         "Please cite the respective ExAC publication alongside the VEP if you use this "
         "resource: https://www.ncbi.nlm.nih.gov/pubmed/27535533",

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -3,10 +3,13 @@ from collections import defaultdict
 from sys import stderr
 from typing import Union, Iterable, Tuple, Dict, Callable, Any
 
-import numpy
-from numpy import float32
+from ctypes import c_float
 
 from .errors import MoreThanOneAltAllele, NotExactlyOneValue
+
+
+def float32(val: str) -> float:
+    return c_float(float(val)).value
 
 
 # If NoValue inherits from str, re.search("something", NoValue()) does not error
@@ -73,7 +76,7 @@ class InfoTuple:
         return len(self.values)
 
 
-IntFloatStr = Union[int, float, str, numpy.floating]
+IntFloatStr = Union[int, float, str]
 
 
 def type_info(value, number=".", field=None, record_idx=None):

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -1,9 +1,10 @@
+import re
 from collections import defaultdict
 from sys import stderr
 from typing import Union, Iterable, Tuple, Dict, Callable, Any
-import re
 
 import numpy
+from numpy import float32
 
 from .errors import MoreThanOneAltAllele, NotExactlyOneValue
 
@@ -284,7 +285,7 @@ class AnnotationPredictionScoreEntry(AnnotationEntry):
     def __init__(self, name: str, **kwargs):
         def typefunc(x: str) -> Dict[str, float]:
             match = PREDICTION_SCORE_REGEXP.findall(x)[0]
-            return {match[0]: numpy.float32(match[1])}
+            return {match[0]: float32(match[1])}
 
         super().__init__(name, typefunc=typefunc, nafunc=lambda: dict(), **kwargs)
 
@@ -436,7 +437,7 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     "MOTIF_SCORE_CHANGE": AnnotationEntry(
         "MOTIF_SCORE_CHANGE",
-        numpy.float32,
+        float32,
         description="The difference in motif score of the reference and variant "
         "sequences for the TFBP",
     ),
@@ -476,113 +477,113 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     #     "FREQS", description="Frequencies of overlapping variants used in filtering"
     # ),
     "AF": AnnotationEntry(
-        "AF", numpy.float32, description="Frequency of existing variant in 1000 Genomes"
+        "AF", float32, description="Frequency of existing variant in 1000 Genomes"
     ),
     "AFR_AF": AnnotationEntry(
         "AFR_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "African population",
     ),
     "AMR_AF": AnnotationEntry(
         "AMR_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "American population",
     ),
     "ASN_AF": AnnotationEntry(
         "ASN_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "Asian population",
     ),
     "EUR_AF": AnnotationEntry(
         "EUR_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "European population",
     ),
     "EAS_AF": AnnotationEntry(
         "EAS_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "East Asian population",
     ),
     "SAS_AF": AnnotationEntry(
         "SAS_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in 1000 Genomes combined "
         "South Asian population",
     ),
     "AA_AF": AnnotationEntry(
         "AA_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in NHLBI-ESP "
         "African American population",
     ),
     "EA_AF": AnnotationEntry(
         "EA_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in NHLBI-ESP "
         "European American population",
     ),
     "gnomAD_AF": AnnotationEntry(
         "gnomAD_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "combined population",
     ),
     "gnomAD_AFR_AF": AnnotationEntry(
         "gnomAD_AFR_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "African/American population",
     ),
     "gnomAD_AMR_AF": AnnotationEntry(
         "gnomAD_AMR_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "American population",
     ),
     "gnomAD_ASJ_AF": AnnotationEntry(
         "gnomAD_ASJ_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "Ashkenazi Jewish population",
     ),
     "gnomAD_EAS_AF": AnnotationEntry(
         "gnomAD_EAS_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "East Asian population",
     ),
     "gnomAD_FIN_AF": AnnotationEntry(
         "gnomAD_FIN_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "Finnish population",
     ),
     "gnomAD_NFE_AF": AnnotationEntry(
         "gnomAD_NFE_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "Non-Finnish European population",
     ),
     "gnomAD_OTH_AF": AnnotationEntry(
         "gnomAD_OTH_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "combined other combined populations",
     ),
     "gnomAD_SAS_AF": AnnotationEntry(
         "gnomAD_SAS_AF",
-        numpy.float32,
+        float32,
         description="Frequency of existing variant in gnomAD exomes "
         "South Asian population",
     ),
     "MAX_AF": AnnotationEntry(
         "MAX_AF",
-        numpy.float32,
+        float32,
         description="Maximum observed allele frequency in "
         "1000 Genomes, ESP and gnomAD",
     ),
@@ -679,7 +680,7 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     "OverlapPC": AnnotationEntry(
         "OverlapPC",
-        numpy.float32,
+        float32,
         description="Percentage of corresponding structural variation feature "
         "overlapped by the given input",
     ),
@@ -730,21 +731,21 @@ KNOWN_ANN_TYPE_MAP_VEP = {
     ),
     "LoFtool": AnnotationEntry(
         "LoFtool",
-        typefunc=numpy.float32,
+        typefunc=float32,
         description="Provides a rank of genic intolerance and "
         "consequent susceptibility to disease based on the ratio of Loss-of-function "
         "(LoF) to synonymous mutations.",
     ),
     "REVEL": AnnotationEntry(
         "REVEL",
-        typefunc=numpy.float32,
+        typefunc=float32,
         description="Estimate of the pathogenicity of missense variants. "
         "Please cite the REVEL publication alongside the VEP if you use this "
         "resource: https://www.ncbi.nlm.nih.gov/pubmed/27666373",
     ),
     "ExACpLI": AnnotationEntry(
         "ExACpLI",
-        typefunc=numpy.float32,
+        typefunc=float32,
         description="Probabililty of a gene being loss-of-function intolerant (pLI). "
         "Please cite the respective ExAC publication alongside the VEP if you use this "
         "resource: https://www.ncbi.nlm.nih.gov/pubmed/27535533",

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -1,8 +1,9 @@
 import math
 import re
 import statistics
-
 from typing import Dict, Any, Iterable
+
+import numpy
 
 from .ann_types import NA
 
@@ -90,7 +91,8 @@ _builtins = {
     )
 }
 
-_modules = {mod.__name__: mod for mod in (re,)}
+
+_modules = {mod.__name__: mod for mod in (re, numpy)}
 
 _math_exports = {
     name: mod for name, mod in vars(math).items() if not name.startswith("__")

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -3,7 +3,7 @@ import re
 import statistics
 from typing import Dict, Any, Iterable
 
-import numpy
+from numpy import float32
 
 from .ann_types import NA
 
@@ -92,7 +92,7 @@ _builtins = {
 }
 
 
-_modules = {mod.__name__: mod for mod in (re, numpy)}
+_modules = {mod.__name__: mod for mod in (re,)}
 
 _math_exports = {
     name: mod for name, mod in vars(math).items() if not name.startswith("__")
@@ -118,7 +118,11 @@ def replace_na(values: Iterable[Any], replacement: Any) -> Iterable[Any]:
             yield replacement
 
 
-_additional_functions = {"without_na": without_na, "replace_na": replace_na}
+_additional_functions = {
+    "without_na": without_na,
+    "replace_na": replace_na,
+    "float32": float32,
+}
 
 _explicit_clear = {
     "__builtins__": {},

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -3,7 +3,6 @@ import re
 import statistics
 from typing import Dict, Any, Iterable
 
-from numpy import float32
 
 from .ann_types import NA
 
@@ -121,7 +120,6 @@ def replace_na(values: Iterable[Any], replacement: Any) -> Iterable[Any]:
 _additional_functions = {
     "without_na": without_na,
     "replace_na": replace_na,
-    "float32": float32,
 }
 
 _explicit_clear = {

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -167,11 +167,9 @@ class WrapFloat32Visitor(ast.NodeTransformer):
             return node
 
         return ast.Call(
-            func=ast.Attribute(
-                value=ast.Name(
-                    id="numpy", ctx=ast.Load()
-                ),  # assumes numpy is available in the global or local namespace
-                attr="float32",
+            func=ast.Name(
+                # assumes float32 is available in the globals
+                id="float32",
                 ctx=ast.Load(),
             ),
             args=[node],

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -161,6 +161,26 @@ class Annotation(NoValueDict):
 UNSET = object()
 
 
+class WrapFloat32Visitor(ast.NodeTransformer):
+    def visit_Constant(self, node):
+        if not isinstance(node.n, float):
+            return node
+
+        return ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(
+                    id="numpy", ctx=ast.Load()
+                ),  # assumes numpy is available in the global or local namespace
+                attr="float32",
+                ctx=ast.Load(),
+            ),
+            args=[node],
+            keywords=[],
+            starargs=None,
+            kwargs=None,
+        )
+
+
 class Environment(dict):
     def __init__(
         self,
@@ -184,7 +204,29 @@ class Environment(dict):
         # REF/ALT alleles are cached separately to raise "MoreThanOneAltAllele"
         # only if ALT (but not REF) is accessed (and ALT has multiple entries).
         self._alleles = None
-        self._func = eval(f"lambda: {expression}", self, {})
+
+        func = f"lambda: {expression}"
+
+        # The VCF specification only allows 32bit floats.
+        # Comparisons such as `INFO["some_float"] > CONST` may yield unexpected results,
+        # because `some_float` is a 32bit float while `CONST` is a python 64bit float.
+        # Example: `c_float(0.6) = 0.6000000238418579 > 0.6`.
+        # We can work around this by wrapping user provided floats in numpy.float32
+        # as follows:
+
+        # parse the expression, obtaining an AST
+        expression_ast = ast.parse(func, mode="eval")
+
+        # wrap each float constant in numpy.float32
+        expression_ast = WrapFloat32Visitor().visit(expression_ast)
+
+        # housekeeping
+        expression_ast = ast.fix_missing_locations(expression_ast)
+
+        # compile the now-fixed code-tree
+        func = compile(expression_ast, filename="expression.py", mode="eval")
+
+        self._func = eval(func, self, {})
 
         self._getters = {
             "AUX": self._get_aux,

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -163,20 +163,12 @@ UNSET = object()
 
 class WrapFloat32Visitor(ast.NodeTransformer):
     def visit_Constant(self, node):
-        if not isinstance(node.n, float):
+        from ctypes import c_float
+
+        if not isinstance(node.value, float):
             return node
 
-        return ast.Call(
-            func=ast.Name(
-                # assumes float32 is available in the globals
-                id="float32",
-                ctx=ast.Load(),
-            ),
-            args=[node],
-            keywords=[],
-            starargs=None,
-            kwargs=None,
-        )
+        return ast.Constant(c_float(node.value).value)
 
 
 class Environment(dict):

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -201,8 +201,9 @@ class Environment(dict):
         # Comparisons such as `INFO["some_float"] > CONST` may yield unexpected results,
         # because `some_float` is a 32bit float while `CONST` is a python 64bit float.
         # Example: `c_float(0.6) = 0.6000000238418579 > 0.6`.
-        # We can work around this by wrapping user provided floats in numpy.float32
-        # as follows:
+        # We can work around this by wrapping user provided floats in `ctypes.c_float`,
+        # which should follow the same IEEE 754 specification as the VCF spec, as most
+        # C compilers should follow this standard (https://stackoverflow.com/a/17904539):
 
         # parse the expression, obtaining an AST
         expression_ast = ast.parse(func, mode="eval")


### PR DESCRIPTION
This "solves" the following issue:
The VCF specification … specifies … 32bit IEEE-754-1985 floats. Both `pysam` and `cyvcf2` use htslib. Htslib uses 32 bit c floats.
vembrane expressions use 64bit floats (see python 3 tutorial on [floating point arithmetic](https://docs.python.org/3/tutorial/floatingpoint.html) which explains the usual issues around floating point arithmetic).

In other words: there's a type disparity between float32 in VCF fields (obtained from htslib) and float64 in the expression (parsed from strings).

From a user's perspective, this can lead to unexpected behaviour:
Given the following pseudo VCF file
```
##INFO=<ID="some_float",Type=Float,Number=1,Description="">
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
chr1	2	.	A	C	.	PASS	some_float=0.6	.
```
and the vembrane filter expression `INFO["some_float"] > 0.6`, a user would expect the record to be discarded.
However, `0.6` can never be represented exactly, in this case `c_float(0.6) == c_float(0.6000000238418579)`, leading to the record to be *kept* instead of discarded (because `c_float(0.6).value > c_double(0.6).value`).

Of course, one should not rely on exact float thresholds anyway (i.e. does it really make a difference whether the test is `foo > 0.6` or `foo > 0.6000000238418579`?).

The solution here parses the expression to obtain its AST, visit all constants that are floats, and wraps those floats in numpy.float32, compiles the modified AST and stores that instead of the string we used to store before.
This necessitates the side-effect of exposing the numpy module in the environment.