### PR TITLE
`--overwrite-number` fixes and pysam special treatment

### DIFF
--- a/tests/testcases/test_overwrite_wrong_number/config.yaml
+++ b/tests/testcases/test_overwrite_wrong_number/config.yaml
@@ -2,4 +2,4 @@ function: "filter"
 expression: 'INFO["INT"] > 0'
 # TypeError: '>' not supported between instances of 'InfoTuple' and 'int'
 raises: "TypeError"
-overwrite_number: "INT=2"
+overwrite_number: ["INT", "2"]

--- a/tests/testcases/test_overwrite_wrong_number/config.yaml
+++ b/tests/testcases/test_overwrite_wrong_number/config.yaml
@@ -2,4 +2,4 @@ function: "filter"
 expression: 'INFO["INT"] > 0'
 # TypeError: '>' not supported between instances of 'InfoTuple' and 'int'
 raises: "TypeError"
-overwrite_number: ["INT", "2"]
+overwrite_number_info: ["INT", "2"]

--- a/vembrane/cli.py
+++ b/vembrane/cli.py
@@ -6,6 +6,7 @@ from . import __version__
 
 def main():
     parser = argparse.ArgumentParser()
+
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )

--- a/vembrane/modules/filter.py
+++ b/vembrane/modules/filter.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import yaml
 
@@ -17,8 +18,18 @@ from ..representations import Environment
 from .. import __version__
 
 
+class DeprecatedAction(argparse.Action):
+    def __call__(self, *args, **kwargs):
+        print(
+            f"{'/'.join(self.option_strings)} is deprecated.\n{self.help}",
+            file=sys.stderr,
+        )
+        exit(1)
+
+
 def add_subcommmand(subparsers):
     parser = subparsers.add_parser("filter")
+    parser.register("action", "deprecated", DeprecatedAction)
     parser.add_argument(
         "expression",
         type=check_expression,
@@ -81,6 +92,12 @@ def add_subcommmand(subparsers):
     )
     parser.add_argument(
         "--overwrite-number",
+        help="Deprecated. "
+        "Use --overwrite-number-info or --overwrite-number-format instead.",
+        action="deprecated",
+    )
+    parser.add_argument(
+        "--overwrite-number-info",
         nargs=2,
         action="append",
         metavar=("FIELD", "NUMBER"),
@@ -268,7 +285,7 @@ def execute(args):
         )
 
         overwrite_number = {
-            "INFO": dict(args.overwrite_number),
+            "INFO": dict(args.overwrite_number_info),
             "FORMAT": dict(args.overwrite_number_format),
         }
 

--- a/vembrane/modules/table.py
+++ b/vembrane/modules/table.py
@@ -7,6 +7,7 @@ from typing import Dict, Iterator, List, Optional
 import asttokens
 from pysam.libcbcf import VariantFile, VariantRecord
 
+from .filter import DeprecatedAction
 from ..common import check_expression
 from ..errors import VembraneError, HeaderWrongColumnNumber
 from ..representations import Environment
@@ -14,6 +15,7 @@ from ..representations import Environment
 
 def add_subcommmand(subparsers):
     parser = subparsers.add_parser("table")
+    parser.register("action", "deprecated", DeprecatedAction)
     parser.add_argument(
         "expression",
         type=check_expression,
@@ -60,6 +62,12 @@ def add_subcommmand(subparsers):
     )
     parser.add_argument(
         "--overwrite-number",
+        help="Deprecated. "
+        "Use --overwrite-number-info or --overwrite-number-format instead.",
+        action="deprecated",
+    )
+    parser.add_argument(
+        "--overwrite-number-info",
         nargs=2,
         action="append",
         metavar=("FIELD", "NUMBER"),
@@ -269,7 +277,7 @@ def execute(args):
     with VariantFile(args.vcf) as vcf:
         expression = preprocess_header_expression(args.expression, vcf, True)
         overwrite_number = {
-            "INFO": dict(args.overwrite_number),
+            "INFO": dict(args.overwrite_number_info),
             "FORMAT": dict(args.overwrite_number_format),
         }
         rows = tableize_vcf(


### PR DESCRIPTION
This PR does several things because these are all pretty much related:

1. The `FORMAT["GT"]` field is always interpreted as a list of integers by pysam, no matter the definition in the header. (The VCF specification says that the community convention is `<ID=GT,Type=String,Number=1>`, which fits for VCF, but BCF stores the GT field quite differently). We therefore now ignore the multiplicity specified in the header (by force-setting it to `"."`).

2. Switch from key-value-with-equals notation `--overwrite-number FIELD=NUM` to key-value-notation-with-space-and-nargs=2 notation `--overwrite-number FIELD NUM` so as to have consistent key-value-pair cli definitions, similar to `--aux NAME FILE`. This change also necessitates being able to use `--overwrite-number` multiple times.

3. Keep `--overwrite-number` for `INFO` fields, add `--overwrite-number-format` for `FORMAT` fields. This is a bit unfortunate, but previously both `INFO[FIELD]` and `FORMAT[FIELD]` were overwritten if the same fieldname was used in both `INFO` and `FORMAT`. Perhaps `--overwrite-number` should be renamed to `--overwrite-number-info` for consistency (or perhaps there is a better way of handling this convenience functionality)?