### PR TITLE
Allow comparisons to `InfoTuple`

### DIFF
--- a/tests/testcases/test_infotuple_comparison/config.yaml
+++ b/tests/testcases/test_infotuple_comparison/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: 'FORMAT["GT"]["S2"] == (1, 1) and FORMAT["GT"]["S3"] == (0, 0) and FORMAT["GT"]["S4"] == (0, 1) and FORMAT["GT"]["S5"] == (1, 0) and FORMAT["GT"]["S6"] == (None, 0) and FORMAT["GT"]["S7"] == (None, 1) and FORMAT["GT"]["S8"] == (1, None) and FORMAT["GT"]["S9"] == (0, None)'

--- a/tests/testcases/test_infotuple_comparison/expected.vcf
+++ b/tests/testcases/test_infotuple_comparison/expected.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=GT,Number=2,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3	S4	S5	S6	S7	S8	S9
+chr18	27963423	.	G	A	276	PASS	.	GT	./.	1/1	0/0	0/1	1/0	./0	./1	1/.	0/.

--- a/tests/testcases/test_infotuple_comparison/test.vcf
+++ b/tests/testcases/test_infotuple_comparison/test.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##source=strelka
+##source_version=2.9.10
+##startTime=Tue Dec 17 17:01:25 2019
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=GT,Number=2,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3	S4	S5	S6	S7	S8	S9
+chr18	27963423	.	G	A	276	PASS	.	GT	./.	1/1	0/0	0/1	1/0	./0	./1	1/.	0/.

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -75,6 +75,19 @@ class InfoTuple:
     def __len__(self):
         return len(self.values)
 
+    def __eq__(self, other):
+        value_type = type(self.values)
+        if isinstance(other, InfoTuple) and isinstance(other.values, value_type):
+            return self.values == other.values
+        elif isinstance(other, value_type):
+            return self.values == other
+        else:
+            raise ValueError(
+                f"Incomparable: "
+                f"{type(self)} (value type: {type(self.values)}), "
+                f"{type(other)}"
+            )
+
 
 IntFloatStr = Union[int, float, str]
 

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -82,10 +82,15 @@ class InfoTuple:
         elif isinstance(other, value_type):
             return self.values == other
         else:
-            raise ValueError(
+            raise TypeError(
                 f"Incomparable: "
                 f"{type(self)} (value type: {type(self.values)}), "
                 f"{type(other)}"
+                + (
+                    f" (value type: {type(other.values)})"
+                    if isinstance(other, InfoTuple)
+                    else ""
+                )
             )
 
     def __hash__(self):

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -88,6 +88,9 @@ class InfoTuple:
                 f"{type(other)}"
             )
 
+    def __hash__(self):
+        return hash(self.values)
+
 
 IntFloatStr = Union[int, float, str]
 


### PR DESCRIPTION
Example: `FORMAT['GT'][SAMPLES[0]]` is of type `InfoTuple`, so comparisons like `FORMAT['GT'][SAMPLES[0]] == (1, 1)` would always return `False`. With a custom `__eq__` implementation, we can check whether the values of two `InfoTuple`s (or one `InfoTuple`s values and some other user provided value, as shown in the example) are equal. This bypasses `__getitem__` which is used to convert `None` to `NA`, but that should not matter for equality checks anway (I hope).