### PR TITLE
return NA in case of MISSING (".") ALT

### DIFF
--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -301,7 +301,7 @@ class Environment(dict):
         alleles = self._get_alleles()
         if len(alleles) > 2:
             raise MoreThanOneAltAllele()
-        value = alleles[1]
+        value = alleles[1] if len(alleles) == 2 else NA
         self._globals["ALT"] = value
         return value
 


### PR DESCRIPTION
When the `ALT` allele is `.`, pysam's `record.alleles` returns only the `REF` allele and no `ALT` allele at all.

This case is now handled when accessing `ALT` and returns `NoValue()` (instead of throwing an index error).
This means that to check for a missing alternate allele, you can now use `ALT is NA`, or if you're using it in an expression something like `ALT or '.'` to provide a default value of `'.'`.

For `vembrane table`, a missing `ALT` will be printed as two double quotes `""`, so it is advisable to indeed use `ALT or '.'` in that case (or we could implement `__new__` for `NoValue` which simply calls its super new constructor with `"."` as the sole argument, but that might cause issues with how we handle missing values for the regexp module. Not sure.)