### PR TITLE
TypeVar instead of Any

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ options:
                         Path to an auxiliary file containing a set of symbols.
   --keep-unmatched      Keep all annotations of a variant if at least one of them
                         passes the expression (mimics SnpSift behaviour).
-  --preserve-order      Ensures that the order of the output matches that of the input. 
+  --preserve-order      Ensures that the order of the output matches that of the input.
                         This is only useful if the input contains breakends (BNDs)
                         since the order of all other variants is preserved anyway.
 ```
@@ -47,8 +47,8 @@ The filter expression can be any valid python expression that evaluates to `bool
  * Any function from [`statistics`](https://docs.python.org/3/library/statistics.html)
  * Regular expressions via [`re`](https://docs.python.org/3/library/re.html)
  * custom functions:
-   * `without_na(values: Iterable[Any]) -> Iterable[Any]` (keep only values that are not `NA`)
-   * `replace_na(values: Iterable[Any], replacement: Any) -> Iterable[Any]` (replace values that are `NA` with some other fixed value)
+   * `without_na(values: Iterable[T]) -> Iterable[T]` (keep only values that are not `NA`)
+   * `replace_na(values: Iterable[T], replacement: T) -> Iterable[T]` (replace values that are `NA` with some other fixed value)
    * genotype related:
      * `count_hom`, `count_het` , `count_any_ref`, `count_any_var`, `count_hom_ref`, `count_hom_var`
      * `is_hom`, `is_het`, `is_hom_ref` , `is_hom_var`

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -108,10 +108,12 @@ T = TypeVar("T")
 
 
 def without_na(values: Iterable[T]) -> Iterable[T]:
+    """Keep only values that are not `NA`."""
     return filter(lambda v: v is not NA, values)
 
 
 def replace_na(values: Iterable[T], replacement: T) -> Iterable[T]:
+    """Replace values that are `NA` with `replacement`."""
     for v in values:
         if v is not NA:
             yield v

--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -1,7 +1,7 @@
 import math
 import re
 import statistics
-from typing import Any, Dict, Iterable
+from typing import Callable, Dict, Iterable, TypeVar
 
 from .ann_types import NA
 
@@ -104,11 +104,14 @@ _statistics_exports = {
 }
 
 
-def without_na(values: Iterable[Any]) -> "filter":
+T = TypeVar("T")
+
+
+def without_na(values: Iterable[T]) -> Iterable[T]:
     return filter(lambda v: v is not NA, values)
 
 
-def replace_na(values: Iterable[Any], replacement: Any) -> Iterable[Any]:
+def replace_na(values: Iterable[T], replacement: T) -> Iterable[T]:
     for v in values:
         if v is not NA:
             yield v
@@ -141,7 +144,7 @@ allowed_globals = {
 }
 
 
-def custom_functions(env) -> Dict[str, Any]:
+def custom_functions(env) -> Dict[str, Callable]:
     return {
         "count_hom": eval(
             "lambda: "


### PR DESCRIPTION
- Prefer concrete type parameter `T` to general `Any`
- Document non-private methods
