### PR TITLE
Explicitly clear builtins in Environment

### DIFF
--- a/vembrane/globals.py
+++ b/vembrane/globals.py
@@ -133,6 +133,7 @@ _explicit_clear = {
     "__name__": None,
     "__doc__": None,
     "__package__": None,
+    "__import__": None,
 }
 
 allowed_globals = {

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -12,7 +12,7 @@ from .errors import (
     UnknownInfoField,
     UnknownSample,
 )
-from .globals import allowed_globals, custom_functions
+from .globals import _explicit_clear, allowed_globals, custom_functions
 
 
 class NoValueDict:
@@ -214,6 +214,7 @@ class Environment(dict):
         # compile the now-fixed code-tree
         func = compile(expression_ast, filename="expression.py", mode="eval")
 
+        self.update(**_explicit_clear)
         self._func = eval(func, self, {})
 
         self._getters = {

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -212,7 +212,7 @@ class Environment(dict):
         expression_ast = ast.fix_missing_locations(expression_ast)
 
         # compile the now-fixed code-tree
-        func = compile(expression_ast, filename="expression.py", mode="eval")
+        func = compile(expression_ast, filename="<string>", mode="eval")
 
         self.update(**_explicit_clear)
         self._func = eval(func, self, {})


### PR DESCRIPTION
While builtins were cleared in `Environment._globals`, they were not cleared in `Environment` itself (which inherits from dict), which is used as the globals context during evaluation.
Also explicitly clear `__import__` and specify the `filename` in `eval` as `<string>`.