### PR TITLE
Add examples for working with sample specific values and genotypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The following VCF fields can be accessed in the filter expression:
 * Filter on sample specific values:
   ```sh
   vembrane filter \
-    'mean(FORMAT["DP"][s] for s in SAMPLES) > 10. and (FORMAT["AD"][SAMPLES[0]] 0 + FORMAT["AD"]["specific_sample_name"]) > 0' \
+    'mean(FORMAT["DP"][s] for s in SAMPLES) > 10 and (FORMAT["AD"][SAMPLES[0]] + FORMAT["AD"]["specific_sample_name"]) > 0' \
     variants.vcf
   ```
 * Filter on genotypes for specific samples (named "kid", "mom", "dad"):

--- a/README.md
+++ b/README.md
@@ -131,15 +131,15 @@ The following VCF fields can be accessed in the filter expression:
 * Filter on sample specific values:
   * by sample name:
     ```sh
-    vembrane filter 'FORMAT["AD"]["specific_sample_name"] > 0' variants.vcf
+    vembrane filter 'FORMAT["DP"]["specific_sample_name"] > 0' variants.vcf
     ```
   * by sample index:
     ```sh
-    vembrane filter 'FORMAT["AD"][0] > 0' variants.vcf
+    vembrane filter 'FORMAT["DP"][0] > 0' variants.vcf
     ```
   * by sample name based on the index in the list of `SAMPLES`:
     ```sh
-    vembrane filter 'FORMAT["AD"][SAMPLES[0]] > 0' variants.vcf
+    vembrane filter 'FORMAT["DP"][SAMPLES[0]] > 0' variants.vcf
     ```
   * using all or a subset of `SAMPLES`:
       ```sh

--- a/README.md
+++ b/README.md
@@ -129,22 +129,31 @@ The following VCF fields can be accessed in the filter expression:
     variants.vcf
   ```
 * Filter on sample specific values:
-  ```sh
-  vembrane filter \
-    'mean(FORMAT["DP"][s] for s in SAMPLES) > 10 and (FORMAT["AD"][SAMPLES[0]] + FORMAT["AD"]["specific_sample_name"]) > 0' \
-    variants.vcf
-  ```
+  * by sample name:
+    ```sh
+    vembrane filter 'FORMAT["AD"]["specific_sample_name"] > 0' variants.vcf
+    ```
+  * by sample index:
+    ```sh
+    vembrane filter 'FORMAT["AD"][0] > 0' variants.vcf
+    ```
+  * by sample name based on the index in the list of `SAMPLES`:
+    ```sh
+    vembrane filter 'FORMAT["AD"][SAMPLES[0]] > 0' variants.vcf
+    ```
+  * using all or a subset of `SAMPLES`:
+      ```sh
+      vembrane filter 'mean(FORMAT["DP"][s] for s in SAMPLES) > 10' variants.vcf
+      ```
+
 * Filter on genotypes for specific samples (named "kid", "mom", "dad"):
   ```sh
   vembrane filter \
-    'is_het("kid") and is_hom_ref("mom") and is_hom_ref("dad") and all(FORMAT["DP"][s] > 10 for s in ["kid", "mom", "dad"])' \
+    'is_het("kid") and is_hom_ref("mom") and is_hom_ref("dad") and \
+     all(FORMAT["DP"][s] > 10 for s in ["kid", "mom", "dad"])' \
     variants.vcf
   ```
 * Explicitly access the `GT` field for the first sample in the file:
-  ```sh
-  vembrane filter 'FORMAT["GT"][SAMPLES[0]] == (1, 1)' variants.vcf
-  ```
-  Samples can be referenced both by index and by name, so the expression could also be written as:
   ```sh
   vembrane filter 'FORMAT["GT"][0] == (1, 1)' variants.vcf
   ```

--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ The following VCF fields can be accessed in the filter expression:
     'not {"pathogenic", "likely_pathogenic", "drug_response"}.isdisjoint(ANN["CLIN_SIG"])' \
     variants.vcf
   ```
+* Filter on sample specific values:
+  ```sh
+  vembrane filter \
+    'mean(FORMAT["DP"][s] for s in SAMPLES) > 10. and (FORMAT["AD"][SAMPLES[0]] 0 + FORMAT["AD"]["specific_sample_name"]) > 0' \
+    variants.vcf
+  ```
+* Filter on genotypes for specific samples (named "kid", "mom", "dad"):
+  ```sh
+  vembrane filter \
+    'is_het("kid") and is_hom_ref("mom") and is_hom_ref("dad") and all(FORMAT["DP"][s] > 10 for s in ["kid", "mom", "dad"])' \
+    variants.vcf
+  ```
+* Explicitly access the `GT` field for the first sample in the file:
+  ```sh
+  vembrane filter 'FORMAT["GT"][SAMPLES[0]] == (1, 1)' variants.vcf
+  ```
+  Samples can be referenced both by index and by name, so the expression could also be written as:
+  ```sh
+  vembrane filter 'FORMAT["GT"][0] == (1, 1)' variants.vcf
+  ```
 
 ### Custom `ANN` types
 `vembrane` parses entries in the annotation field as outlined in [docs/ann_types.md](docs/ann_types.md).


### PR DESCRIPTION
This PR adds examples for working with sample specific values and genotypes to the README.
Showcases:
 - sample access by both name and index
 - custom genotype related functions `is_het` and `is_hom_ref`
 - access to `FORMAT` values in general