### PR TITLE
Add '.raw' getter property to custom types to get original annotation string

### DIFF
--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -127,14 +127,15 @@ def type_info(value, number=".", field=None, record_idx=None):
 
 
 class PosRange:
-    def __init__(self, start: int, end: int):
+    def __init__(self, start: int, end: int, raw: str):
         self.start = start
         self.end = end
+        self._raw = raw
 
     @classmethod
     def from_snpeff_str(cls, value: str) -> PosRange:
         pos, length = [int(v.strip()) for v in value.split("/")]
-        return cls(pos, pos + length)
+        return cls(pos, pos + length, value)
 
     @classmethod
     def from_vep_str(cls, value: str) -> PosRange:
@@ -145,7 +146,10 @@ class PosRange:
             #  or start position only
             else [int(value.strip())] * 2
         )
-        return cls(start, end)
+        return cls(start, end, value)
+
+    def raw(self) -> str:
+        return self._raw
 
     @property
     def length(self):
@@ -239,23 +243,27 @@ class AnnotationListDictEntry(AnnotationEntry):
 
 
 class RangeTotal(object):
-    def __init__(self, r, total):
+    def __init__(self, r: range, total: int, raw: str):
         self.range = r
         self.total = total
+        self._raw = raw
 
     @classmethod
     def from_vep_string(cls, value: str) -> RangeTotal:
         v = value.split("/")
         r = [int(s) for s in v[0].split("-")]
         if len(r) == 1:
-            return cls(range(r[0], r[0] + 1), int(v[1]))
+            return cls(range(r[0], r[0] + 1), int(v[1]), value)
         elif len(r) == 2:
-            return cls(range(r[0], r[1] + 1), int(v[1]))
+            return cls(range(r[0], r[1] + 1), int(v[1]), value)
         else:
             raise ValueError(
                 "Found more than two values separated by '-', "
                 "expected only a single int, or two ints separated by '-'."
             )
+
+    def raw(self) -> str:
+        return self._raw
 
     def __str__(self):
         if len(self.range) == 1:
@@ -280,14 +288,18 @@ class AnnotationRangeTotalEntry(AnnotationEntry):
 
 
 class NumberTotal(object):
-    def __init__(self, number, total):
+    def __init__(self, number: int, total: int, raw: str):
         self.number = number
         self.total = total
+        self._raw = raw
 
     @classmethod
     def from_vep_string(cls, value: str) -> NumberTotal:
         v = value.split("/")
-        return cls(int(v[0]), int(v[1]))
+        return cls(int(v[0]), int(v[1]), value)
+
+    def raw(self) -> str:
+        return self._raw
 
     def __str__(self):
         return f"number / total: {self.number} / {self.total}"

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -132,6 +132,8 @@ class PosRange:
         self.end = end
         self._raw = raw
 
+    raw = property(lambda self: self._raw, None, None)
+
     @classmethod
     def from_snpeff_str(cls, value: str) -> PosRange:
         pos, length = [int(v.strip()) for v in value.split("/")]
@@ -147,9 +149,6 @@ class PosRange:
             else [int(value.strip())] * 2
         )
         return cls(start, end, value)
-
-    def raw(self) -> str:
-        return self._raw
 
     @property
     def length(self):
@@ -248,6 +247,8 @@ class RangeTotal(object):
         self.total = total
         self._raw = raw
 
+    raw = property(lambda self: self._raw, None, None)
+
     @classmethod
     def from_vep_string(cls, value: str) -> RangeTotal:
         v = value.split("/")
@@ -261,9 +262,6 @@ class RangeTotal(object):
                 "Found more than two values separated by '-', "
                 "expected only a single int, or two ints separated by '-'."
             )
-
-    def raw(self) -> str:
-        return self._raw
 
     def __str__(self):
         if len(self.range) == 1:
@@ -293,13 +291,12 @@ class NumberTotal(object):
         self.total = total
         self._raw = raw
 
+    raw = property(lambda self: self._raw, None, None)
+
     @classmethod
     def from_vep_string(cls, value: str) -> NumberTotal:
         v = value.split("/")
         return cls(int(v[0]), int(v[1]), value)
-
-    def raw(self) -> str:
-        return self._raw
 
     def __str__(self):
         return f"number / total: {self.number} / {self.total}"


### PR DESCRIPTION
Add a property called `raw` to custom types in order to get the original annotation string (which is parsed to the custom type).