### PR TITLE
`PosRange` specific fixes

### DIFF
--- a/tests/testcases/table_ann_exon_range_undefined/config.yaml
+++ b/tests/testcases/table_ann_exon_range_undefined/config.yaml
@@ -1,2 +1,2 @@
 function: "table"
-expression: "CHROM, POS, ANN['Protein_position'].start, ANN['Protein_position'].length"
+expression: "CHROM, POS, ANN['Protein_position'].start, ANN['Protein_position'].length, ANN['Protein_position']"

--- a/tests/testcases/table_ann_exon_range_undefined/config.yaml
+++ b/tests/testcases/table_ann_exon_range_undefined/config.yaml
@@ -1,0 +1,2 @@
+function: "table"
+expression: "CHROM, POS, ANN['Protein_position'].start, ANN['Protein_position'].length"

--- a/tests/testcases/table_ann_exon_range_undefined/expected.tsv
+++ b/tests/testcases/table_ann_exon_range_undefined/expected.tsv
@@ -1,0 +1,6 @@
+CHROM	POS	ANN['Protein_position'].start	ANN['Protein_position'].length
+1	12	1	3
+1	23		
+1	34	5	5
+1	45	5	
+1	56	42	1

--- a/tests/testcases/table_ann_exon_range_undefined/expected.tsv
+++ b/tests/testcases/table_ann_exon_range_undefined/expected.tsv
@@ -1,6 +1,6 @@
-CHROM	POS	ANN['Protein_position'].start	ANN['Protein_position'].length
-1	12	1	3
-1	23		
-1	34	5	5
-1	45	5	
-1	56	42	1
+CHROM	POS	ANN['Protein_position'].start	ANN['Protein_position'].length	ANN['Protein_position']
+1	12	1	3	(start: 1, end: 4, length: 3)
+1	23			(start: , end: 4, length: )
+1	34	5	5	(start: 5, end: 10, length: 5)
+1	45	5		(start: 5, end: , length: )
+1	56	42	1	(start: 42, end: 43, length: 1)

--- a/tests/testcases/table_ann_exon_range_undefined/test.vcf
+++ b/tests/testcases/table_ann_exon_range_undefined/test.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##contig=<ID=1,length=1234567>
+##INFO=<ID=ANN,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: 'Allele|EXON|Protein_position'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	tumor
+1	12	.	A	C	.	.	ANN=C|8/31|1-4	.		
+1	23	.	A	C	.	.	ANN=C|8/31|?-4	.		
+1	34	.	A	C	.	.	ANN=C|8/31|5-10	.		
+1	45	.	A	C	.	.	ANN=C|8/31|5-?	.		
+1	56	.	A	C	.	.	ANN=C|8/31|42	.		

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -139,11 +139,11 @@ class PosRange:
     @classmethod
     def from_vep_str(cls, value: str) -> PosRange:
         start, end = (
-            #  the "-" is optional, so vep either has either start and end position
+            #  the "-" is optional, so vep either has start and end position
             [NA if v == "?" else int(v) for v in map(str.strip, value.split("-"))]
             if "-" in value
             #  or start position only
-            else [int(value.strip())] * 2
+            else [int(value.strip()), int(value.strip()) + 1]
         )
         return cls(start, end)
 

--- a/vembrane/ann_types.py
+++ b/vembrane/ann_types.py
@@ -149,7 +149,7 @@ class PosRange:
 
     @property
     def length(self):
-        if self.end != NA and self.start != NA:
+        if self.end is not NA and self.start is not NA:
             return self.end - self.start
         else:
             return NA


### PR DESCRIPTION
1) Assume a single position corresponds to the end-exclusive range `position-(position + 1)`.
2) When checking if either of start or end position is unspecified, check for `NA` explicitly (not with `!=`, which is always true for `NA`!).