### PR TITLE
Support `--aux` for vembrane table.

### DIFF
--- a/vembrane/common.py
+++ b/vembrane/common.py
@@ -1,7 +1,7 @@
 import argparse
 import ast
 import shlex
-from typing import Iterable, Iterator, List, Optional
+from typing import Dict, Iterable, Iterator, List, Optional, Set
 
 from pysam.libcbcf import VariantHeader, VariantRecord
 
@@ -123,3 +123,12 @@ class AppendKeyValuePair(argparse.Action):
         value = values[0].strip()
         key, value = value.strip().split("=", 1)
         getattr(namespace, self.dest)[key.strip()] = value
+
+
+def read_auxiliary(aux: Dict[str, str]) -> Dict[str, Set[str]]:
+    # read auxiliary files, split at any whitespace and store contents in a set
+    def read_set(path: str) -> Set[str]:
+        with open(path, "rt") as f:
+            return set(line.rstrip() for line in f)
+
+    return {name: read_set(contents) for name, contents in aux.items()}

--- a/vembrane/modules/filter.py
+++ b/vembrane/modules/filter.py
@@ -17,6 +17,7 @@ from ..common import (
     is_bnd_record,
     mate_key,
     normalize,
+    read_auxiliary,
     split_annotation_entry,
 )
 from ..errors import VembraneError
@@ -307,15 +308,6 @@ def statistics(
     yaml.add_representer(defaultdict, yaml.representer.Representer.represent_dict)
     with open(filename, "w") as out:
         yaml.dump(dict(counter), out)
-
-
-def read_auxiliary(aux: Dict[str, str]) -> Dict[str, Set[str]]:
-    # read auxiliary files, split at any whitespace and store contents in a set
-    def read_set(path: str) -> Set[str]:
-        with open(path, "rt") as f:
-            return set(line.rstrip() for line in f)
-
-    return {name: read_set(contents) for name, contents in aux.items()}
 
 
 def execute(args):

--- a/vembrane/modules/table.py
+++ b/vembrane/modules/table.py
@@ -2,12 +2,12 @@ import contextlib
 import csv
 import sys
 from sys import stderr
-from typing import Dict, Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional, Set
 
 import asttokens
 from pysam.libcbcf import VariantFile, VariantRecord
 
-from ..common import AppendKeyValuePair, check_expression
+from ..common import AppendKeyValuePair, check_expression, read_auxiliary
 from ..errors import HeaderWrongColumnNumber, VembraneError
 from ..globals import allowed_globals
 from ..representations import Environment
@@ -40,13 +40,6 @@ def add_subcommmand(subparsers):
         help="Define the field separator (default: \\t).",
     )
     parser.add_argument(
-        "--all",
-        "-a",
-        default=False,
-        action="store_true",
-        help="Do not filter duplicate entries.",
-    )
-    parser.add_argument(
         "--header",
         default="auto",
         metavar="TEXT",
@@ -67,6 +60,15 @@ def add_subcommmand(subparsers):
         "-o",
         default="-",
         help="Output file, if not specified, output is written to STDOUT.",
+    )
+    parser.add_argument(
+        "--aux",
+        "-a",
+        nargs=1,
+        action=AppendKeyValuePair,
+        metavar="NAME=PATH",
+        default={},
+        help="Path to an auxiliary file containing a set of symbols",
     )
     parser.add_argument(
         "--overwrite-number-info",
@@ -96,8 +98,9 @@ def tableize_vcf(
     ann_key: str,
     overwrite_number: Dict[str, Dict[str, str]] = {},
     long: bool = False,
+    auxiliary: Dict[str, Set[str]] = {},
 ) -> Iterator[tuple]:
-    kwargs = dict(overwrite_number=overwrite_number)
+    kwargs = dict(overwrite_number=overwrite_number, auxiliary=auxiliary)
     if long:
         kwargs[
             "evaluation_function_template"
@@ -285,6 +288,7 @@ def smart_open(filename=None, *args, **kwargs):
 
 
 def execute(args):
+    aux = read_auxiliary(args.aux)
     with VariantFile(args.vcf) as vcf:
         expression = preprocess_expression(args.expression, vcf, True)
         if args.long:
@@ -299,6 +303,7 @@ def execute(args):
             args.annotation_key,
             overwrite_number=overwrite_number,
             long=args.long,
+            auxiliary=aux,
         )
 
         try:

--- a/vembrane/modules/tag.py
+++ b/vembrane/modules/tag.py
@@ -12,12 +12,13 @@ from ..common import (
     AppendTagExpression,
     check_expression,
     normalize,
+    read_auxiliary,
     single_outer,
     swap_quotes,
 )
 from ..errors import FilterAlreadyDefined, FilterTagNameInvalid, VembraneError
 from ..representations import Environment
-from .filter import DeprecatedAction, read_auxiliary
+from .filter import DeprecatedAction
 
 
 def add_subcommand(subparsers):


### PR DESCRIPTION
This PR adds support for the `--aux name=file` option also available for filter and tag.
It also removes the `--all` option, which I had no idea existed and did not do anything.