### PR TITLE
fix: When a record is missing an entry for ANN, replace with ||||…

### DIFF
--- a/tests/testcases/test_filter_missing_ann/config.yaml
+++ b/tests/testcases/test_filter_missing_ann/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: 'ANN["Allele"] == "C"'

--- a/tests/testcases/test_filter_missing_ann/expected.vcf
+++ b/tests/testcases/test_filter_missing_ann/expected.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##SnpEffVersion="4.3t (build 2017-11-24 10:18), by Pablo Cingolani"
+##SnpEffCmd="SnpEff  hg38 - "
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+chr18	27963698	.	T	C	30	PASS	ANN=C|intron_variant|MODIFIER|CDH2	GT	0/1
+chr18	46546946	.	T	C	2045	PASS	ANN=C|missense_variant|MODERATE|LOXHD1	GT	1/1

--- a/tests/testcases/test_filter_missing_ann/test.vcf
+++ b/tests/testcases/test_filter_missing_ann/test.vcf
@@ -1,0 +1,14 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##SnpEffVersion="4.3t (build 2017-11-24 10:18), by Pablo Cingolani"
+##SnpEffCmd="SnpEff  hg38 - "
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+chr18	27963698	.	T	C	30	PASS	ANN=C|intron_variant|MODIFIER|CDH2	GT	0/1
+chr18	28036487	.	A	T	162	PASS	ANN=T|stop_gained|HIGH|CDH2	GT	0/1
+chr18	28045161	.	G	A	37	PASS	ANN=A|intron_variant|MODIFIER|CDH2	GT	0/1
+chr18	36126053	.	T	C	40	PASS		GT	0/1
+chr18	46546946	.	T	C	2045	PASS	ANN=C|missense_variant|MODERATE|LOXHD1	GT	1/1

--- a/vembrane/modules/filter.py
+++ b/vembrane/modules/filter.py
@@ -133,7 +133,14 @@ def test_and_update_record(
         try:
             annotations = record.info[ann_key]
         except KeyError:
-            annotations = [""]
+            num_ann_entries = len(env._annotation._ann_conv.keys())
+            empty = "|" * num_ann_entries
+            print(
+                f"No ANN field found in record {idx}, "
+                f"replacing with NAs (i.e. 'ANN={empty}')",
+                file=sys.stderr,
+            )
+            annotations = [empty]
 
         #  … and only keep the annotations where the expression evaluates to true
         if keep_unmatched:


### PR DESCRIPTION
When
- the VCF header defines the `ANN` `INFO` field,
- the expression makes use of `ANN` and
- a record does not have any value defined for `INFO["ANN"]`
this resulted in an error.
With this change (only for the case described above) `ANN` is set to `"|" * n` where `n` is the number of `ANN` keys defined in the header and a warning is issued.