### PR TITLE
fix: handle missing `ANN`-field for `vembrane table`

### DIFF
--- a/tests/testcases/test_table_missing_ann/config.yaml
+++ b/tests/testcases/test_table_missing_ann/config.yaml
@@ -1,0 +1,5 @@
+function: "table"
+expression: 'ANN["Gene_Name"] in AUX["genes"] and ANN["Annotation_Impact"] == "HIGH"'
+header: "known_with_high_impact"
+aux:
+  genes: 'tests/testcases/test_auxiliary_gene_set/genes.txt'

--- a/tests/testcases/test_table_missing_ann/expected.tsv
+++ b/tests/testcases/test_table_missing_ann/expected.tsv
@@ -1,0 +1,9 @@
+known_with_high_impact
+False
+False
+True
+False
+False
+False
+False
+False

--- a/tests/testcases/test_table_missing_ann/test.vcf
+++ b/tests/testcases/test_table_missing_ann/test.vcf
@@ -1,0 +1,17 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##SnpEffVersion="4.3t (build 2017-11-24 10:18), by Pablo Cingolani"
+##SnpEffCmd="SnpEff  hg38 - "
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+chr18	27963423	.	G	A	276	PASS	ANN=A|synonymous_variant|LOW|CDH2	GT	0/1
+chr18	27963698	.	T	C	30	PASS		GT	0/1
+chr18	28036487	.	A	T	162	PASS	ANN=T|stop_gained|HIGH|CDH2	GT	0/1
+chr18	28045161	.	G	A	37	PASS	ANN=A|intron_variant|MODIFIER|CDH2	GT	0/1
+chr18	36126053	.	T	C	40	PASS	ANN=C|upstream_gene_variant|MODIFIER|ELP2	GT	0/1
+chr18	36126651	.	C	G	1771	PASS	ANN=G|missense_variant|MODERATE|SLC39A6	GT	1/1
+chr18	46546946	.	T	C	2045	PASS	ANN=C|missense_variant|MODERATE|LOXHD1	GT	1/1
+chr18	47034729	.	C	G	272	PASS	ANN=G|missense_variant|MODERATE|TCEB3B	GT	0/1

--- a/vembrane/modules/table.py
+++ b/vembrane/modules/table.py
@@ -121,7 +121,14 @@ def tableize_vcf(
             try:
                 annotations = record.info[ann_key]
             except KeyError:
-                annotations = [""]
+                num_ann_entries = len(env._annotation._ann_conv.keys())
+                empty = "|" * num_ann_entries
+                print(
+                    f"No ANN field found in record {idx}, "
+                    f"replacing with NAs (i.e. 'ANN={empty}')",
+                    file=sys.stderr,
+                )
+                annotations = [empty]
             for annotation in annotations:
                 if long:
                     yield from env.table(annotation)


### PR DESCRIPTION
When a record in a vcf/bcf file does not have a `ANN` field vembrane fails on running `vembrane table`.
This is solved by adding an empty `ANN` field entry to each record without that field (see https://github.com/vembrane/vembrane/pull/146).