### PR TITLE
fix: Check if MATEID and EVENT are specified in the VCF header prior to accessing the fields

### DIFF
--- a/tests/testcases/test_breakend_missing_mateid/config.yaml
+++ b/tests/testcases/test_breakend_missing_mateid/config.yaml
@@ -1,0 +1,3 @@
+function: "filter"
+expression: 'any(v == 2 for v in INFO["ints"])'
+#preserve_order: []

--- a/tests/testcases/test_breakend_missing_mateid/expected.vcf
+++ b/tests/testcases/test_breakend_missing_mateid/expected.vcf
@@ -1,0 +1,16 @@
+##fileformat=VCFv4.3
+##fileDate=20222807
+##reference=fake_reference
+##contig=<ID=fake,length=1234567>
+##INFO=<ID=ints,Number=2,Type=Integer,Description="Two integers">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1
+fake	100	bnd_1_0	A	]fake:150]A	.	PASS	SVTYPE=BND;ints=1,2	.	.
+fake	125	.	T	G	.	PASS	ints=0,2	.	.
+fake	225	.	T	G	.	PASS	ints=0,2	.	.
+fake	325	.	T	G	.	PASS	ints=0,2	.	.
+fake	400	bnd_4_0	A	]fake:450]A	.	PASS	SVTYPE=BND;ints=1,2	.	.
+fake	425	.	T	G	.	PASS	ints=0,2	.	.
+fake	500	.	A	]fake:550]A	.	PASS	SVTYPE=BND;ints=1,2	.	.
+fake	525	.	T	G	.	PASS	ints=0,2	.	.

--- a/tests/testcases/test_breakend_missing_mateid/test.vcf
+++ b/tests/testcases/test_breakend_missing_mateid/test.vcf
@@ -1,0 +1,18 @@
+##fileformat=VCFv4.3
+##fileDate=20222807
+##reference=fake_reference
+##contig=<ID=fake,length=1234567>
+##INFO=<ID=ints,Number=2,Type=Integer,Description="Two integers">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1
+fake	100	bnd_1_0	A	]fake:150]A	.	PASS	SVTYPE=BND;ints=1,2	.	.
+fake	125	.	T	G	.	PASS	ints=0,2	.	.
+fake	150	bnd_1_1	C	C[fake:100[	.	PASS	SVTYPE=BND	.	.
+fake	225	.	T	G	.	PASS	ints=0,2	.	.
+fake	325	.	T	G	.	PASS	ints=0,2	.	.
+fake	400	bnd_4_0	A	]fake:450]A	.	PASS	SVTYPE=BND;ints=1,2	.	.
+fake	425	.	T	G	.	PASS	ints=0,2	.	.
+fake	450	bnd_4_1	C	C[fake:400[	.	PASS	SVTYPE=BND;	.	.
+fake	500	.	A	]fake:550]A	.	PASS	SVTYPE=BND;ints=1,2	.	.
+fake	525	.	T	G	.	PASS	ints=0,2	.	.
+fake	550	.	C	C[fake:500[	.	PASS	SVTYPE=BND;	.	.

--- a/vembrane/modules/filter.py
+++ b/vembrane/modules/filter.py
@@ -172,10 +172,18 @@ def filter_vcf(
     overwrite_number: Dict[str, Dict[str, str]] = {},
 ) -> Iterator[VariantRecord]:
     env = Environment(expression, ann_key, vcf.header, auxiliary, overwrite_number)
+    has_mateid_key = vcf.header.info.get("MATEID", None) is not None
+    has_event_key = vcf.header.info.get("EVENT", None) is not None
 
-    def get_event_name(record: VariantRecord) -> Tuple[Optional[str], Optional[str]]:
-        mate_ids: List[str] = record.info.get("MATEID", [])
-        event_name: Optional[str] = record.info.get("EVENT", None)
+    def get_event_name(
+        record: VariantRecord,
+        has_mateid_key=has_mateid_key,
+        has_event_key=has_event_key,
+    ) -> Tuple[Optional[str], Optional[str]]:
+        mate_ids: List[str] = record.info.get("MATEID", []) if has_mateid_key else []
+        event_name: Optional[str] = (
+            record.info.get("EVENT", None) if has_event_key else None
+        )
 
         if len(mate_ids) > 1 and not event_name:
             raise ValueError(
@@ -201,7 +209,7 @@ def filter_vcf(
             )
 
             # Breakend records *may* have the "EVENT" specified, but don't have to.
-            # In that case only the MATEID *may* bee available
+            # In that case only the MATEID *may* be available
             # (which may contain more than one ID)
             if is_bnd_record(record):
                 event_name, mate_pair_name = get_event_name(record)


### PR DESCRIPTION
When `SVTYPE == BND` but neither `MATEID` nor `EVENT` are given, the header entries for `MATEID` and `EVENT` may not be present. In that case, these records are treated as regular records, similar to when both MATEID and EVENT are empty.
Fixes #151