### PR TITLE
Enhancement: Raise error for filter expressions which do not evaluate to `bool`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ options:
 
 ### Filter expression
 The filter expression can be any valid python expression that evaluates to a value of *type* `bool`.
+If you want to use truthy values, you need to wrap the expression in `bool()`, or aggregate multiple values via `any()` or `all()`.
 
 However, functions and symbols available have been restricted to the following:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ options:
 
 
 ### Filter expression
-The filter expression can be any valid python expression that evaluates to `bool`. However, functions and symbols available have been restricted to the following:
+The filter expression can be any valid python expression that evaluates to a value of *type* `bool`.
+
+However, functions and symbols available have been restricted to the following:
 
  * `all`, `any`
  * `abs`, `len`, `max`, `min`, `round`, `sum`

--- a/vembrane/errors.py
+++ b/vembrane/errors.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pysam import VariantRecord
 
 
@@ -129,4 +131,15 @@ class FilterTagNameInvalid(VembraneError):
         super(FilterTagNameInvalid, self).__init__(
             f"Filter '{tag}' contains invalid characters (whitespace or semicolon) "
             f"or is '0'."
+        )
+
+
+class NonBoolTypeError(VembraneError):
+    def __init__(self, value: Any):
+        super(NonBoolTypeError, self).__init__(
+            "The expression does not evaluate to bool, "
+            f"but to {type(value)} ({value}).\n"
+            "If you wish to use truthy values, "
+            "explicitly wrap the expression in `bool(…)`, "
+            "or aggregate multiple values via `any(…)` or `all(…)`."
         )

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -1,7 +1,6 @@
 import ast
 from enum import Enum
 from itertools import chain
-from sys import stderr
 from types import CodeType
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -18,6 +17,7 @@ from .ann_types import (
 )
 from .common import get_annotation_keys, is_bnd_record, split_annotation_entry
 from .errors import (
+    NonBoolTypeError,
     UnknownAnnotation,
     UnknownFormatField,
     UnknownInfoField,
@@ -397,15 +397,7 @@ class Environment(dict):
             self._annotation.update(self.idx, self.record, annotation)
         keep = self._func()
         if not isinstance(keep, bool):
-            if Warnings.NonBoolType not in self._warnings:
-                print(
-                    f"Warning: Expression did not evaluate to bool, "
-                    f"but to {type(keep)}: {keep}. "
-                    f"This might indicate a missing aggregation, "
-                    f"e.g. `any(…)` or `all(…)`.",
-                    file=stderr,
-                )
-                self._warnings.add(Warnings.NonBoolType)
+            raise NonBoolTypeError(keep)
         return keep
 
     def table(self, annotation: str = "") -> tuple:

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -1,5 +1,4 @@
 import ast
-from enum import Enum
 from itertools import chain
 from types import CodeType
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -24,10 +23,6 @@ from .errors import (
     UnknownSample,
 )
 from .globals import _explicit_clear, allowed_globals, custom_functions
-
-
-class Warnings(Enum):
-    NonBoolType = 1
 
 
 class NoValueDict:
@@ -199,8 +194,6 @@ class WrapFloat32Visitor(ast.NodeTransformer):
 
 
 class Environment(dict):
-    _warnings: Set[str] = set()
-
     def __init__(
         self,
         expression: str,


### PR DESCRIPTION
This PR addresses #154 by adding a check on the result of the filter expression. If it's `bool`, all is well, otherwise, print a warning but continue, because someone might want to use a truth-y value as a filter.