### PR TITLE
working info

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -1,0 +1,9 @@
+info:
+    genehancer_score: # a new info entry in the info field of the vcf named genehancer_score
+        number: "1" # number of values for each entry
+        description: "Score from genehancer." # description of this entry in the header
+        type: "Float" # type of the values
+    genehancer_score2: # a second annotation entry to annotate
+        number: "1"
+        description: "Score from genehancer anything."
+        type: "Float"

--- a/vembrane/modules/annotate.py
+++ b/vembrane/modules/annotate.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from sys import stderr
 from typing import Any, Callable, Dict, Iterator
+import ast
 
 import numpy as np
 import yaml
@@ -10,16 +11,30 @@ from pysam.libcbcf import VariantFile, VariantRecord
 from ..common import check_expression
 from ..representations import Environment
 
+from functools import partial
+
 
 def add_subcommmand(subparsers):
     parser = subparsers.add_parser("annotate")
     parser.add_argument(
-        "config",
+        "target",
+        # type=check_expression,
+        help="Assign the expression values to these targets.",
+    )
+    parser.add_argument(
+        "expression",
         type=check_expression,
-        help="The configuration file.",
+        help="Annotate variants and annotations.",
     )
     parser.add_argument(
         "vcf", help="The file containing the variants.", nargs="?", default="-"
+    )
+    parser.add_argument(
+        "--definitions",
+        "-d",
+        metavar="FILENAME",
+        default=None,
+        help="A file containing additional info and annotation definitions.",
     )
     parser.add_argument(
         "--annotation-key",
@@ -54,135 +69,139 @@ typeparser: Dict[str, Callable[[str], Any]] = {
 
 def annotate_vcf(
     vcf: VariantFile,
+    target: str,
     expression: str,
     ann_key: str,
-    ann_data,
-    config: dict,
 ) -> Iterator[VariantRecord]:
     env = Environment(expression, ann_key, vcf.header)
 
-    config_chrom_column = config["annotation"]["columns"]["chrom"]
-    config_start_column = config["annotation"]["columns"]["start"]
-    config_stop_column = config["annotation"]["columns"]["stop"]
+    def set_info(record, value, t):
+        getattr(record, "info")[t] = value
 
-    available_chromsomes = set(np.unique(ann_data[config_chrom_column]))
-
-    tree = dict()
-    chrom_ann_data = dict()
-    for chrom in available_chromsomes:
-        d = ann_data[ann_data[config_chrom_column] == chrom]
-        chrom_ann_data[chrom] = d
-        tree[chrom] = IntervalTree(
-            Interval(d[config_start_column], d[config_stop_column], i)
-            for i, d in enumerate(d)
-        )
-
-        # tree = IntervalTree.from_tuples(interval_tuples))
-
-    current_chrom = None
-    current_ann_data = None
+    target_func = []
+    # print(target, file=stderr)
+    for e in ast.parse(target).body[0].value.elts:
+        if e.value.id == "INFO":
+            target_func.append(partial(set_info, t=e.slice.value))
+        elif e.value.id == "ANN":
+            pass
+        else:
+            pass  # throw error
 
     record: VariantRecord
     for idx, record in enumerate(vcf):
-        chrom = None
-        if current_chrom != record.chrom:
-            current_chrom = record.chrom
+        ann_values = env.table()
+        for t, v in zip(target_func, ann_values):
+            t(record, v)
 
-            # find the correct chrom name
-            tmp = current_chrom
-            if tmp.lower().startswith("chr"):
-                tmp = tmp[3:]
-            for prefix in ["", "chr", "Chr", "CHR"]:
-                if prefix + tmp in available_chromsomes:
-                    chrom = prefix + tmp
-                    current_ann_data = chrom_ann_data[chrom]
-                    t = tree[chrom]
+        # print(getattr(record, "info")["SNVHPOL"], file=stderr)
+        # print(ast.parse(target), file=stderr)
 
-        if chrom:
-            indices = np.fromiter((i for _, _, i in t[record.start]), dtype=int)
-            if len(indices):
-                env.update_data(current_ann_data[(np.array(indices))])
-                env.update_from_record(idx, record)
-                ann_values = env.table()
+        # print(dir(list(ast.iter_child_nodes(ast.parse(target, mode="eval")))[0]), file=stderr)
+        # print("ast", dir(ast.parse(target, mode="eval")), file=stderr)
+        # print("ann_values 2", target, ann_values, file=stderr)
+        # for t, v in zip(ann_values):
+        #     print(t, v)
+        # for v, expression_value in zip(
+        #     map(lambda x: x["info"], config["annotation"]["values"]),
+        #     ann_values,
+        # ):
+        #     if not v["number"] == ".":
+        #         number = int(v["number"])
+        #     else:
+        #         number = -1
 
-                for v, expression_value in zip(
-                    map(lambda x: x["value"], config["annotation"]["values"]),
-                    ann_values,
-                ):
-                    if not v["number"] == ".":
-                        number = int(v["number"])
-                    else:
-                        number = -1
-
-                    parse = typeparser[v["type"]]
-                    if number == -1:
-                        expression_value = list(map(parse, expression_value))
-                    elif number > 1:
-                        expression_value = list(map(parse, expression_value))
-                        assert len(expression_value) == number
-                    else:
-                        # number == 1
-                        assert isinstance(expression_value, str) or not isinstance(
-                            expression_value, Iterable
-                        )
-                        expression_value = parse(expression_value)
-                    record.info[v["vcf_name"]] = expression_value
+        #     parse = typeparser[v["type"]]
+        #     if number == -1:
+        #         expression_value = list(map(parse, expression_value))
+        #     elif number > 1:
+        #         expression_value = list(map(parse, expression_value))
+        #         assert len(expression_value) == number
+        #     else:
+        #         # number == 1
+        #         assert isinstance(expression_value, str) or not isinstance(
+        #             expression_value, Iterable
+        #         )
+        #         expression_value = parse(expression_value)
+        #     record.info[v["vcf_name"]] = expression_value
 
         yield record
 
 
 def execute(args):
-    with open(args.config, "r") as stream:
-        try:
-            config = yaml.safe_load(stream)
-        except yaml.YAMLError as e:
-            print(e, file=stderr)
-            exit(1)
-
-    # load annotation data
-    ann_data = np.genfromtxt(
-        config["annotation"]["file"],
-        delimiter=config["annotation"].get("delimiter", "\t"),
-        names=True,
-        dtype=None,
-        encoding=None,
-    )
-    # ann_data = pd.read_csv(config["annotation"]["file"], sep="\t", header=0)
-    # ann_data = dict(tuple(ann_data.groupby("chrom")))
-
-    # build expression
-    expression = ",".join(
-        f'{value["expression"]}'
-        for value in map(lambda x: x["value"], config["annotation"]["values"])
-    )
-    expression = f"({expression})"
-
     with VariantFile(args.vcf) as vcf:
-        # add new info
-        for value in config["annotation"]["values"]:
-            value = value["value"]
-            vcf.header.add_meta(
-                "INFO",
-                items=[
-                    ("ID", value["vcf_name"]),
-                    ("Number", value["number"]),
-                    ("Type", value["type"]),
-                    ("Description", value["description"]),
-                ],
-            )
+        if args.definitions:
+            # add or modify meta defitions
+            with open(args.definitions, "r") as stream:
+                try:
+                    definitions = yaml.safe_load(stream)
+                except yaml.YAMLError as e:
+                    print(e, file=stderr)
+                    exit(1)
+            for name in (infos := definitions.get("info", {})):
+                if name in vcf.header.info.keys():
+                    continue
+                values = infos[name]
+                vcf.header.add_meta(
+                    "INFO",
+                    items=[
+                        ("ID", name),
+                        ("Number", values["number"]),
+                        ("Type", values["type"]),
+                        ("Description", values["description"]),
+                    ],
+                )
 
+        expression = f"({args.expression})"
+        target = args.target
         fmt = {"vcf": "", "bcf": "b", "uncompressed-bcf": "u"}[args.output_fmt]
         with VariantFile(
             args.output,
             f"w{fmt}",
             header=vcf.header,
         ) as out:
+            pass
             variants = annotate_vcf(
                 vcf,
+                target,
                 expression,
                 args.annotation_key,
-                ann_data=ann_data,
-                config=config,
             )
             for v in variants:
                 out.write(v)
+
+    # expression = []
+
+    # with VariantFile(args.vcf) as vcf:
+    #     # add new info
+    #     for value in config["annotation"]["values"]:
+    #         if (v := value.get("info", None)):
+    #             vcf.header.add_meta(
+    #                 "INFO",
+    #                 items=[
+    #                     ("ID", v["vcf_name"]),
+    #                     ("Number", v["number"]),
+    #                     ("Type", v["type"]),
+    #                     ("Description", v["description"]),
+    #                 ],
+    #             )
+    #             expression.append(v["expression"])
+
+    #     expression = ",".join(expression)
+    #     expression = f"({expression})"
+
+    #     fmt = {"vcf": "", "bcf": "b", "uncompressed-bcf": "u"}[args.output_fmt]
+    #     with VariantFile(
+    #         args.output,
+    #         f"w{fmt}",
+    #         header=vcf.header,
+    #     ) as out:
+    #         variants = annotate_vcf(
+    #             vcf,
+    #             expression,
+    #             args.annotation_key,
+    #             ann_data=ann_data,
+    #             config=config,
+    #         )
+    #         for v in variants:
+    #             out.write(v)

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -201,6 +201,7 @@ class Environment(dict):
         auxiliary: Dict[str, Set[str]] = {},
         overwrite_number: Dict[str, Dict[str, str]] = {},
         evaluation_function_template: str = "lambda: {expression}",
+        mode="eval",
     ):
         self._ann_key: str = ann_key
         self._has_ann: bool = any(
@@ -228,7 +229,7 @@ class Environment(dict):
         # compilers should follow this standard (https://stackoverflow.com/a/17904539):
 
         # parse the expression, obtaining an AST
-        expression_ast = ast.parse(func_str, mode="eval")
+        expression_ast = ast.parse(func_str, mode=mode)
 
         # wrap each float constant in numpy.float32
         expression_ast = WrapFloat32Visitor().visit(expression_ast)
@@ -237,7 +238,7 @@ class Environment(dict):
         expression_ast = ast.fix_missing_locations(expression_ast)
 
         # compile the now-fixed code-tree
-        func: CodeType = compile(expression_ast, filename="<string>", mode="eval")
+        func: CodeType = compile(expression_ast, filename="<string>", mode=mode)
 
         self.update(**_explicit_clear)
         self._func = eval(func, self, {})


### PR DESCRIPTION
This is a complete rework of the annotate command. The goal is to make annotate similar to filter and table, extend it by the possibility to add annotations and make use of an external definition.yaml, that defines the new fields. Additionally allow the user to change existing INFO and ANN values. Later on this should be extended to all available fields, such as PASS or QUAL.

This branch will be crucial to the upcoming database branch

The current invoke command is

```
vembrane annotate "INFO['genehancer_score'],INFO['genehancer_score2']" "123,456" tests/testcases/test01/test.vcf -d definitions.yaml
```

THE WORK ON THIS BRANCH IS ONGOING, DONT MERGE YET!