### PR TITLE
enhancement: Always report record on error

### DIFF
--- a/tests/testcases/test_malformed_ann/config.yaml
+++ b/tests/testcases/test_malformed_ann/config.yaml
@@ -1,0 +1,3 @@
+function: "filter"
+expression: 'ANN["missing_in_the_second_record"]'
+raises: "MalformedAnnotationError"

--- a/tests/testcases/test_malformed_ann/expected.tsv
+++ b/tests/testcases/test_malformed_ann/expected.tsv
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | missing_in_the_second_record'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+chr18	27963423	.	G	A	276	PASS	ANN=A|synonymous_variant|LOW|CDH2|present	GT	0/1
+chr18	27963698	malformed_ann	T	C	30	PASS	ANN=C|intron_variant|MODIFIER|CDH2	GT	0/1
+chr18	28036487	.	A	T	162	PASS	ANN=T|stop_gained|HIGH|CDH2|present	GT	0/1

--- a/tests/testcases/test_malformed_ann/test.vcf
+++ b/tests/testcases/test_malformed_ann/test.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20191217
+##contig=<ID=chr18,length=80373285>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | missing_in_the_second_record'">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+chr18	27963423	.	G	A	276	PASS	ANN=A|synonymous_variant|LOW|CDH2|present	GT	0/1
+chr18	27963698	malformed_ann	T	C	30	PASS	ANN=C|intron_variant|MODIFIER|CDH2	GT	0/1
+chr18	28036487	.	A	T	162	PASS	ANN=T|stop_gained|HIGH|CDH2|present	GT	0/1

--- a/vembrane/errors.py
+++ b/vembrane/errors.py
@@ -20,6 +20,20 @@ class UnknownAnnotation(VembraneError):
         self.key = key
 
 
+class MalformedAnnotationError(VembraneError):
+    """Unknown annotation entry"""
+
+    def __init__(self, record_idx: int, record: VariantRecord, key: str, ann_idx: int):
+        super(MalformedAnnotationError, self).__init__(
+            f"The annotation index {ann_idx} ('{key}') in record {record_idx} is out of bounds. "
+            f"The ANN field might be malformed for this record:\n{str(record)}"
+        )
+        self.record_idx = record_idx
+        self.record = record
+        self.key = key
+        self.ann_idx = ann_idx
+
+
 class UnknownSample(VembraneError, KeyError):
     """Unknown Sample"""
 

--- a/vembrane/modules/filter.py
+++ b/vembrane/modules/filter.py
@@ -125,6 +125,23 @@ def test_and_update_record(
     ann_key: str,
     keep_unmatched: bool,
 ) -> Tuple[VariantRecord, bool]:
+    try:
+        return _test_and_update_record(env, idx, record, ann_key, keep_unmatched)
+    except VembraneError as e:
+        raise e
+    except Exception as e:
+        print(f"Encountered an error while processing record {idx}", file=stderr)
+        print(str(record), file=stderr)
+        raise e
+
+
+def _test_and_update_record(
+    env: Environment,
+    idx: int,
+    record: VariantRecord,
+    ann_key: str,
+    keep_unmatched: bool,
+) -> Tuple[VariantRecord, bool]:
     env.update_from_record(idx, record)
     if env.expression_annotations():
         # if the expression contains a reference to the ANN field

--- a/vembrane/representations.py
+++ b/vembrane/representations.py
@@ -16,6 +16,7 @@ from .ann_types import (
 )
 from .common import get_annotation_keys, is_bnd_record, split_annotation_entry
 from .errors import (
+    MalformedAnnotationError,
     UnknownAnnotation,
     UnknownFormatField,
     UnknownInfoField,
@@ -174,6 +175,8 @@ class Annotation(NoValueDict, DefaultGet):
                 ann_idx, convert = self._ann_conv[item]
             except KeyError:
                 raise UnknownAnnotation(self._record_idx, self._record, item)
+            if ann_idx >= len(self._annotation_data):
+                raise MalformedAnnotationError(self._record_idx, self._record, item, ann_idx)
             raw_value = self._annotation_data[ann_idx].strip()
             value = self._data[item] = convert(raw_value)
             return value


### PR DESCRIPTION
This PR addresses #156 by catching any exception, printing the record and re-raising the exception.
Additionally, it adds a specific error type for "malformed" annotation strings, which at the moment only triggers when the accessed index is out of bounds (i.e. cannot catch errors where e.g. the number of fields is correct, but the order of fields is non-standard).