### PR TITLE
fix: properly handle MATEID presented as single-item

### DIFF
--- a/tests/testcases/filter/test_breakend_mateid_one_item_encoding/config.yaml
+++ b/tests/testcases/filter/test_breakend_mateid_one_item_encoding/config.yaml
@@ -1,0 +1,2 @@
+function: "filter"
+expression: 'True'

--- a/tests/testcases/filter/test_breakend_mateid_one_item_encoding/expected.vcf
+++ b/tests/testcases/filter/test_breakend_mateid_one_item_encoding/expected.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.3
+##fileDate=20222807
+##reference=fake_reference
+##contig=<ID=fake,length=1234567>
+##INFO=<ID=ints,Number=2,Type=Integer,Description="Two integers">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=MATEID,Number=1,Type=String,Description="ID of mate breakends">
+##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1
+fake	100	bnd_1_0	A	]fake:150]A	.	PASS	SVTYPE=BND;MATEID=bnd_1_1;ints=1,2	.	.
+fake	150	bnd_1_1	C	C[fake:100[	.	PASS	SVTYPE=BND;MATEID=bnd_1_0	.	.

--- a/tests/testcases/filter/test_breakend_mateid_one_item_encoding/test.vcf
+++ b/tests/testcases/filter/test_breakend_mateid_one_item_encoding/test.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.3
+##fileDate=20222807
+##reference=fake_reference
+##contig=<ID=fake,length=1234567>
+##INFO=<ID=ints,Number=2,Type=Integer,Description="Two integers">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=MATEID,Number=1,Type=String,Description="ID of mate breakends">
+##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1
+fake	100	bnd_1_0	A	]fake:150]A	.	PASS	SVTYPE=BND;MATEID=bnd_1_1;ints=1,2	.	.
+fake	150	bnd_1_1	C	C[fake:100[	.	PASS	SVTYPE=BND;MATEID=bnd_1_0	.	.

--- a/vembrane/modules/filter.py
+++ b/vembrane/modules/filter.py
@@ -183,7 +183,12 @@ def filter_vcf(
         has_mateid_key: bool = has_mateid_key,
         has_event_key: bool = has_event_key,
     ) -> tuple[str | None, str | None]:
-        mate_ids: list[str] = record.info.get("MATEID", []) if has_mateid_key else []
+        mate_ids: list[str] | str = (
+            record.info.get("MATEID", []) if has_mateid_key else []
+        )
+        if isinstance(mate_ids, str):
+            # some callers annotate MATEID as single string
+            mate_ids = [mate_ids]
         event_name: str | None = (
             record.info.get("EVENT", None) if has_event_key else None
         )


### PR DESCRIPTION
This is relevant for the SAVANA caller, which encodes MATEID as follows:
`##INFO=<ID=MATEID,Number=1,Type=String,Description="ID of mate breakends">`