### PR TITLE
fix: handle SV record for vembrane fhir

### DIFF
--- a/vembrane/backend/base.py
+++ b/vembrane/backend/base.py
@@ -175,6 +175,34 @@ class VCFRecord:
         return "SVTYPE" in self.info and self.info.get("SVTYPE", None) == "BND"
 
     @property
+    def is_sv_record(self) -> bool:
+        is_sv = self.info.get("SVTYPE", "") in [
+            "DEL",
+            "INS",
+            "DUP",
+            "CNV",
+            "INV",
+            "INDEL",
+            "BND",
+            "TRA",
+        ] or any(
+            alt
+            in [
+                "<DEL>",
+                "<DEL:ME>",
+                "<INS>",
+                "<INS:ME>",
+                "<DUP>",
+                "<DUP:TANDEM>",
+                "<CNV>",
+                "<CNV:TR>",
+                "<INV>",
+            ]
+            for alt in self.alt_alleles
+        )
+        return is_sv
+
+    @property
     def end(self):
         if self.is_bnd_record:
             return NA

--- a/vembrane/modules/structured.py
+++ b/vembrane/modules/structured.py
@@ -111,7 +111,8 @@ def process_vcf(
 
     for idx, record in enumerate(vcf):
         try:
-            # TODO: For now structural variants are not supported but should be added later.
+            # TODO: For now structural variants are not supported
+            # but should be added later.
             if record.info.get("SVTYPE", "") in [
                 "CNV",
                 "INDEL",

--- a/vembrane/modules/structured.py
+++ b/vembrane/modules/structured.py
@@ -111,6 +111,21 @@ def process_vcf(
 
     for idx, record in enumerate(vcf):
         try:
+            # TODO: For now structural variants are not supported but should be added later.
+            if record.info.get("SVTYPE", "") in [
+                "CNV",
+                "INDEL",
+                "BND",
+                "INV",
+                "TRA",
+                "DEL",
+                "DUP",
+            ]:
+                print(
+                    f"Warning: Error is a structural variant which are currently not supported and will be skipped.\n"
+                    f"Record: {record}"
+                )
+                continue
             code_handler.update_from_record(idx, record)
             annotations = annotation.get_record_annotations(idx, record)
 
@@ -164,8 +179,9 @@ def process(
     overwrite_number_format,
     backend,
     variables: Dict[str, Any] | None = None,
-    postprocess: Callable[[Primitive | dict | list], Primitive | dict | list]
-    | None = None,
+    postprocess: (
+        Callable[[Primitive | dict | list], Primitive | dict | list] | None
+    ) = None,
 ) -> None:
     overwrite_number = {
         "INFO": dict(overwrite_number_info),

--- a/vembrane/modules/structured.py
+++ b/vembrane/modules/structured.py
@@ -122,7 +122,8 @@ def process_vcf(
                 "DUP",
             ]:
                 print(
-                    f"Warning: Error is a structural variant which are currently not supported and will be skipped.\n"
+                    f"Warning: Error is a structural variant which are currently "
+                    f"not supported and will be skipped.\n"
                     f"Record: {record}"
                 )
                 continue

--- a/vembrane/modules/structured.py
+++ b/vembrane/modules/structured.py
@@ -113,17 +113,9 @@ def process_vcf(
         try:
             # TODO: For now structural variants are not supported
             # but should be added later.
-            if record.info.get("SVTYPE", "") in [
-                "CNV",
-                "INDEL",
-                "BND",
-                "INV",
-                "TRA",
-                "DEL",
-                "DUP",
-            ]:
+            if record.is_sv_record:
                 print(
-                    f"Warning: Error is a structural variant which are currently "
+                    f"Warning: Record is a structural variant which are currently "
                     f"not supported and will be skipped.\n"
                     f"Record: {record}"
                 )


### PR DESCRIPTION
In case bcf records are structure variants the vembrane fhir subcommand failes as those records are currently not supported by the fhir profile.
To support such bcf files each record containing a structural variant will be skipped after checking the SVTYPE info field. In case the info field is not present the records are implicitly assumed to be a snv.

@johanneskoester We talked about which SVs need to be skipped. If I remember correctly we agreed that insertions should work.