### PR TITLE
fix: more modern error base class constructor syntax

### DIFF
--- a/vembrane/errors.py
+++ b/vembrane/errors.py
@@ -37,7 +37,7 @@ class UnknownAnnotationError(VembraneError):
 
 
 class MalformedAnnotationError(VembraneError):
-    """Unknown annotation entry"""
+    """Malformed annotation entry"""
 
     def __init__(self, record, key: str, ann_idx: int) -> None:
         super().__init__(

--- a/vembrane/errors.py
+++ b/vembrane/errors.py
@@ -28,7 +28,7 @@ class UnknownAnnotationError(VembraneError):
     """Unknown annotation entry"""
 
     def __init__(self, record, key: str) -> None:
-        super(UnknownAnnotationError, self).__init__(
+        super().__init__(
             f"No ANN entry for '{key}' in record {record.record_idx}:\n{str(record)}",
         )
         self.record_idx = record.record_idx
@@ -68,7 +68,7 @@ class UnknownFormatFieldError(VembraneError, KeyError):
     """Unknown FORMAT key"""
 
     def __init__(self, record, field: str) -> None:
-        super(UnknownFormatFieldError, self).__init__(
+        super().__init__(
             f"No FORMAT field '{field}' in record \
                 {record.record_idx}:\n{str(record)}",
         )
@@ -174,7 +174,7 @@ class FilterTagNameInvalidError(VembraneError):
 
 class NonBoolTypeError(VembraneError):
     def __init__(self, value: Any):
-        super(NonBoolTypeError, self).__init__(
+        super().__init__(
             "The expression does not evaluate to bool, "
             f"but to {type(value)} ({value}).\n"
             "If you wish to use truthy values, "


### PR DESCRIPTION
This is a follow-up to a fix on one of the instances of this in #208. It resolves the comment here:
https://github.com/vembrane/vembrane/pull/208#discussion_r2225807685